### PR TITLE
Require `--out` in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `Error::UnsupportedOutputFormat`
+
+### Changed
+- CLI: `--out` is now required. `-` can still be passed to write to stdout instead of a file.
+- CLI: The file extension for the `--out` path is now checked to see if it a supported format.
+
+### Removed
+- Removed tga feature in image since it wasn't used
 
 ## [0.4.1] - 2019-09-04
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --out-fmt jpg generate -- imgs/1.jpg > out/01.jpg`
+`cargo run --release -- --out out/01.jpg generate -- imgs/1.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/8p6nVYl.jpg" width="600" height="364">
@@ -93,7 +93,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --rand-init 10 --seed 211 --in-size 300 --debug-out-dir out generate -- imgs/multiexample/1.jpg imgs/multiexample/2.jpg imgs/multiexample/3.jpg imgs/multiexample/4.jpg > out/02.png`
+`cargo run --release -- --rand-init 10 --seed 211 --in-size 300 -o out/02.png --debug-out-dir out generate -- imgs/multiexample/1.jpg imgs/multiexample/2.jpg imgs/multiexample/3.jpg imgs/multiexample/4.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/tbz5d57.jpg" width="600" height="364">
@@ -128,7 +128,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- generate --target-guide imgs/masks/2_target.jpg --guides imgs/masks/2_example.jpg -- imgs/2.jpg > out/03.png`
+`cargo run --release -- -o out/03.png generate --target-guide imgs/masks/2_target.jpg --guides imgs/masks/2_example.jpg -- imgs/2.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/arTCi2f.jpg" width="600" height="364">
@@ -165,7 +165,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --alpha 0.8 transfer-style --style imgs/multiexample/4.jpg --guide imgs/tom.jpg > out/04.png`
+`cargo run --release -- --alpha 0.8 -o out/04.png transfer-style --style imgs/multiexample/4.jpg --guide imgs/tom.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/1E7eDAb.jpg" width="600" height="364">
@@ -211,7 +211,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --in-size 400 --out-size 400 --inpaint imgs/masks/3_inpaint.jpg generate -- imgs/3.jpg > out/05.png`
+`cargo run --release -- --in-size 400 --out-size 400 --inpaint imgs/masks/3_inpaint.jpg -o out/05.png generate -- imgs/3.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/WZm2HHL.jpg" width="600" height="364">
@@ -251,7 +251,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --inpaint imgs/masks/1_tile.jpg --in-size 400 --out-size 400 --tiling generate --examples imgs/1.jpg > out/06.png`
+`cargo run --release -- --inpaint imgs/masks/1_tile.jpg --in-size 400 --out-size 400 --tiling -o out/06.bmp generate -- imgs/1.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/foSlREz.jpg" width="600" height="364">

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -186,6 +186,15 @@ fn main() {
 fn real_main() -> Result<(), Error> {
     let args = Opt::from_args();
 
+    // Check that the extension for the path supplied by the user is one of the ones we support
+    {
+        match args.output_path.extension().and_then(|ext| ext.to_str()) {
+            Some("png") | Some("jpg") | Some("bmp") => {},
+            None => {},
+            Some(other) => return Err(Error::UnsupportedOutputFormat(other.to_owned())),
+        }
+    }
+
     let (mut examples, target_guide) = match &args.cmd {
         Subcommand::Generate(gen) => {
             let mut examples: Vec<_> = gen.examples.iter().map(Example::new).collect();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -189,8 +189,8 @@ fn real_main() -> Result<(), Error> {
     // Check that the extension for the path supplied by the user is one of the ones we support
     {
         match args.output_path.extension().and_then(|ext| ext.to_str()) {
-            Some("png") | Some("jpg") | Some("bmp") => {},
-            None => {},
+            Some("png") | Some("jpg") | Some("bmp") => {}
+            None => {}
             Some(other) => return Err(Error::UnsupportedOutputFormat(other.to_owned())),
         }
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,4 +35,4 @@ features = []
 [dependencies.image]
 version = "0.22.1"
 default-features = false
-features = ["jpeg", "png_codec", "tga", "bmp"]
+features = ["jpeg", "png_codec", "bmp"]

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -78,7 +78,9 @@ impl fmt::Display for Error {
                 }
             }
             Self::Io(io) => write!(f, "{}", io),
-            Self::UnsupportedOutputFormat(fmt) => write!(f, "the output format '{}' is not supported", fmt),
+            Self::UnsupportedOutputFormat(fmt) => {
+                write!(f, "the output format '{}' is not supported", fmt)
+            }
             Self::NoExamples => write!(
                 f,
                 "at least 1 example must be available as a sampling source"

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -49,6 +49,8 @@ pub enum Error {
     ExampleGuideMismatch(u32, u32),
     /// Io is notoriously error free with no problems, but we cover it just in case!
     Io(std::io::Error),
+    /// The user specified an image format we don't support as the output
+    UnsupportedOutputFormat(String),
     /// There are no examples to source pixels from, either because no examples
     /// were added, or all of them used SampleMethod::Ignore
     NoExamples,
@@ -76,6 +78,7 @@ impl fmt::Display for Error {
                 }
             }
             Self::Io(io) => write!(f, "{}", io),
+            Self::UnsupportedOutputFormat(fmt) => write!(f, "the output format '{}' is not supported", fmt),
             Self::NoExamples => write!(
                 f,
                 "at least 1 example must be available as a sampling source"


### PR DESCRIPTION
Also fixes up the README examples and does early error detection for unsupported output formats. Removed tga as it was not supported.