### PR TITLE
Disable unused rand crate features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
 - Disabled unused `rand` default features (OS random number generator)
 
 ## [0.4.2] - 2019-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Disabled unused `rand` default features (OS random number generator)
 
 ## [0.4.2] - 2019-09-05
 ### Added

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["/imgs"]
 crossbeam-utils = "0.6"
 modulo = "0.1.2"
 num_cpus = "1.10.1"
-rand = { version = "0.7.0", default_features = false } # avoid bringing in OS random gen that we don't use
+rand = { version = "0.7.0", default-features = false } # avoid bringing in OS random gen that we don't use
 rand_pcg = "0.2.0"
 rstar = "0.5.0"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["/imgs"]
 crossbeam-utils = "0.6"
 modulo = "0.1.2"
 num_cpus = "1.10.1"
-rand = "0.7.0"
+rand = { version = "0.7.0", default_features = false } # avoid bringing in OS random gen that we don't use
 rand_pcg = "0.2.0"
 rstar = "0.5.0"
 


### PR DESCRIPTION
We do not use or need the OS random number generation which is included with the default features of rand. This avoids bringing in the `getrandom` crate