### PR TITLE
Improve performance by about 50%

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -637,6 +637,10 @@ impl Generator {
 
         let is_tiling_mode = params.tiling_mode;
 
+        let cauchy_precomputed = PrerenderedU8Function::new(|a, b| {
+            metric_cauchy(a, b, params.cauchy_dispersion * params.cauchy_dispersion)
+        });
+        let l2_precomputed = PrerenderedU8Function::new(metric_l2);
         let mut total_processed_pixels = 0;
         let max_workers = params.max_thread_count;
 
@@ -677,6 +681,13 @@ impl Generator {
             } else {
                 0.0 //only care for content, not guidance
             };
+
+            let guide_cost_precomputed =
+                PrerenderedU8Function::new(|a, b| adaptive_alpha * l2_precomputed.get(a, b));
+
+            let my_inverse_alpha_cost_precomputed = PrerenderedU8Function::new(|a, b| {
+                (1.0 - adaptive_alpha) * cauchy_precomputed.get(a, b)
+            });
 
             // Keep track of how many items have been processed. Goes up to `pixels_to_resolve`
             let processed_pixel_count = AtomicUsize::new(0);
@@ -809,6 +820,16 @@ impl Generator {
                                 let candidates_guide_patterns =
                                     &candidates_guide_patterns[0..candidates.len()];
 
+                                let my_cost = if guidance_bool {
+                                    &my_inverse_alpha_cost_precomputed
+                                } else {
+                                    &cauchy_precomputed
+                                };
+                                let guide_cost = if guidance_bool {
+                                    Some(&guide_cost_precomputed)
+                                } else {
+                                    None
+                                };
                                 // 4. find best match based on the candidate patterns
                                 let (best_match, score) = find_best_match(
                                     &candidates,
@@ -817,9 +838,8 @@ impl Generator {
                                     &my_guide_pattern,
                                     &candidates_guide_patterns,
                                     &k_neighs_dist,
-                                    guidance_bool,
-                                    adaptive_alpha,
-                                    params.cauchy_dispersion,
+                                    &my_cost,
+                                    guide_cost,
                                 );
 
                                 let best_match_coord = best_match.coord.0.to_unsigned();
@@ -943,12 +963,17 @@ fn find_best_match<'a>(
     my_guide_pattern: &ColorPattern,
     candidates_guide_patterns: &[ColorPattern],
     k_distances: &[f64], //weight by distance
-    use_guidance: bool,
-    guide_alpha: f32,
-    cauchy_dispersion: f32,
+    my_cost: &PrerenderedU8Function,
+    guide_cost: Option<&PrerenderedU8Function>,
 ) -> (&'a CandidateStruct, Score) {
     let mut best_match = 0;
     let mut lowest_cost = std::f32::MAX;
+
+    let distance_gaussians: Vec<f32> = k_distances
+        .iter()
+        .map(|d| *d as f32)
+        .map(|d| f32::exp(-1f32 * d))
+        .collect();
 
     for i in 0..candidates_patterns.len() {
         if let Some(cost) = better_match(
@@ -956,10 +981,9 @@ fn find_best_match<'a>(
             &candidates_patterns[i],
             &my_guide_pattern,
             &candidates_guide_patterns[i],
-            k_distances,
-            use_guidance,
-            guide_alpha,
-            cauchy_dispersion,
+            distance_gaussians.as_slice(),
+            my_cost,
+            guide_cost,
             lowest_cost,
         ) {
             lowest_cost = cost;
@@ -976,34 +1000,25 @@ fn better_match(
     candidate_pattern: &ColorPattern,
     my_guide_pattern: &ColorPattern,
     candidate_guide_pattern: &ColorPattern,
-    distances: &[f64], //weight by distance
-    use_guidance: bool,
-    mut guide_alpha: f32,
-    dispersion: f32,
+    distance_gaussians: &[f32], //weight by distance
+    my_cost: &PrerenderedU8Function,
+    guide_cost: Option<&PrerenderedU8Function>,
     current_best: f32,
 ) -> Option<f32> {
-    let sig2 = dispersion * dispersion;
-
     let mut score: f32 = 0.0; //minimize score
-    let variance = 0.5;
 
     #[allow(clippy::needless_range_loop)]
     for i in 0..my_pattern.0.len() {
-        let dist_gaussian = (-0.5 * (distances[i] / variance)).exp() as f32;
+        let dist_gaussian = distance_gaussians[i];
 
         //take into account the guidance if needed
-        if use_guidance {
-            score += guide_alpha
-                * metric_l2(my_guide_pattern.0[i], candidate_guide_pattern.0[i])
-                * dist_gaussian;
-        } else {
-            guide_alpha = 0.0;
+        if let Some(guide_cost_fn) = guide_cost {
+            // these are precomputed
+            score += dist_gaussian
+                * guide_cost_fn.get(my_guide_pattern.0[i], candidate_guide_pattern.0[i]);
         }
 
-        //color map comparisons w cauchy
-        score += (1.0 - guide_alpha)
-            * metric_cauchy(my_pattern.0[i], candidate_pattern.0[i], sig2)
-            * dist_gaussian;
+        score += dist_gaussian * my_cost.get(my_pattern.0[i], candidate_pattern.0[i]);
 
         if score >= current_best {
             return None;
@@ -1011,6 +1026,28 @@ fn better_match(
     }
 
     Some(score)
+}
+
+struct PrerenderedU8Function {
+    data: [f32; 65536],
+}
+
+impl PrerenderedU8Function {
+    pub fn new<F: Fn(u8, u8) -> f32>(function: F) -> PrerenderedU8Function {
+        let mut data = [0f32; 65536];
+
+        for a in 0..255u8 {
+            for b in 0..255u8 {
+                data[a as usize * 256usize + b as usize] = function(a, b);
+            }
+        }
+
+        PrerenderedU8Function { data }
+    }
+
+    pub fn get(&self, a: u8, b: u8) -> f32 {
+        self.data[a as usize * 256usize + b as usize]
+    }
 }
 
 fn check_coord_validity(

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -971,8 +971,9 @@ fn find_best_match<'a>(
 
     let distance_gaussians: Vec<f32> = k_distances
         .iter()
-        .map(|d| *d as f32)
-        .map(|d| f32::exp(-1f32 * d))
+        .copied()
+        .map(|d| f64::exp(-1.0f64 * d))
+        .map(|d| d as f32)
         .collect();
 
     for i in 0..candidates_patterns.len() {
@@ -1036,8 +1037,8 @@ impl PrerenderedU8Function {
     pub fn new<F: Fn(u8, u8) -> f32>(function: F) -> PrerenderedU8Function {
         let mut data = [0f32; 65536];
 
-        for a in 0..255u8 {
-            for b in 0..255u8 {
+        for a in 0..=255u8 {
+            for b in 0..=255u8 {
                 data[a as usize * 256usize + b as usize] = function(a, b);
             }
         }


### PR DESCRIPTION
I ran cargo flamegraph, and it turns out a huge portion of the runtime was spent in find_match and find_better_match.  It's a very, very hot loop.

Almost all of the work done in the inner loop (find_better_match) is a function of two u8s... it can be memoized/precomputed!  Also, the alpha masks can be rendered into these precomputed cost functions, avoiding the need to do any alpha computations in the loop.

I looked hard for a way to improve dist_gaussian within find_better_match, but the best I could do was precompute outside the find_best_match loop.  It still helped a lot.

The performance improvement ranges from 40%-60% in the examples.  I ran them all before/after to get performance numbers:

Baseline (f93022):
```
$ time cargo run --release --example 01_single_example_synthesis
real	0m35.907s
user	1m42.443s
sys	0m1.703s

$ time cargo run --release --example 02_multi_example_synthesis
real	0m35.078s
user	1m40.583s
sys	0m1.439s

$ time cargo run --release --example 03_guided_synthesis
real	0m54.007s
user	2m52.701s
sys	0m1.350s

$ time cargo run --release --example 04_style_transfer
real	1m1.137s
user	3m2.301s
sys	0m1.432s

$ time cargo run --release --example 05_inpaint
real	0m7.112s
user	0m17.274s
sys	0m0.606s

$ time cargo run --release --example 06_tiling_texture
real	0m17.468s
user	0m44.012s
sys	0m0.844s
```


Patched (6a97e0):
```
$ time cargo run --release --example 01_single_example_synthesis
real	0m15.504s
user	0m50.723s
sys	0m0.714s

$ time cargo run --release --example 02_multi_example_synthesis
real	0m22.895s
user	0m55.519s
sys	0m1.365s

$ time cargo run --release --example 03_guided_synthesis
real	0m36.120s
user	1m46.536s
sys	0m1.203s

$ time cargo run --release --example 04_style_transfer
real	0m33.324s
user	1m44.423s
sys	0m0.888s

$ time cargo run --release --example 05_inpaint
real	0m2.747s
user	0m7.814s
sys	0m0.139s

$ time cargo run --release --example 06_tiling_texture
real	0m10.338s
user	0m21.917s
sys	0m0.756s
```

I didn't see any visible artifacts in the output.  This is a lossless optimization!