### PR TITLE
Fix stack overflow on Windows

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -1030,12 +1030,12 @@ fn better_match(
 }
 
 struct PrerenderedU8Function {
-    data: [f32; 65536],
+    data: Vec<f32>,
 }
 
 impl PrerenderedU8Function {
     pub fn new<F: Fn(u8, u8) -> f32>(function: F) -> PrerenderedU8Function {
-        let mut data = [0f32; 65536];
+        let mut data = vec![0f32; 65536];
 
         for a in 0..=255u8 {
             for b in 0..=255u8 {


### PR DESCRIPTION
64k floats seems too much for Windows, as they overflow the stack as soon as execution enters `main_resolve_loop`. The look-up-table is now a `Vec`.