### PR TITLE
Fix rare threading-related hang, progress bar jump

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -636,11 +636,7 @@ impl Generator {
         let mut pyramid_level = 0;
 
         let stage_pixels_to_resolve = |p_stage: i32| {
-            if p_stage >= 0 {
-                (params.p.powf(p_stage as f32) * (total_pixels_to_resolve as f32)) as usize
-            } else {
-                total_pixels_to_resolve
-            }
+            (params.p.powf(p_stage as f32) * (total_pixels_to_resolve as f32)) as usize
         };
 
         let actual_total_pixels_to_resolve =
@@ -673,12 +669,7 @@ impl Generator {
                 u64::from(Pcg32::seed_from_u64(params.seed + p_stage as u64).gen::<u32>());
 
             //how many pixels do we need to resolve in this stage
-            let pixels_to_resolve = if p_stage >= 0 {
-                (params.p.powf(p_stage as f32) * (total_pixels_to_resolve as f32)) as usize
-            } else {
-                total_pixels_to_resolve
-            };
-
+            let pixels_to_resolve = stage_pixels_to_resolve(p_stage);
             let redo_count = self.resolved.get_mut().unwrap().len() - self.locked_resolved;
 
             // Start with serial execution for the first few pixels, then go wide


### PR DESCRIPTION
Fixes #23.

There was a chance that the `resolved` pixel list would not be flushed for a while. If that while happened to coincide with the end of a stage, `redo_count` would be lower than expected at the start of the next stage. This in turn caused the `let next_unresolved = if i < redo_count {` conditional to go into the `else` clause too early, trying to grab an unresolved pixel. Eventually, it could run out of pixels to resolve, thus exiting the loop with a `break`.

Meanwhile the progress bar thread would sit there, waiting until `processed_pixel_count >= pixels_to_resolve - n_workers` which would never happen, since `processed_pixel_count` got short-circuited.

The `resolved` list is now explicitly flushed between stages, and the progress bar thread no longer waits until a specific condition is met; only until all the threads have finished.

This also fixes #24.