### PR TITLE
Add support for alpha channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,6 @@ matrix:
     os: linux
     script: .ci/lint.sh
 
-  # We do the exact same checks on the beta channel, as both
-  # rustfmt and clippy can change their behavior between releases
-  # and introduce new diffs/lints compared to stable
-  - name: "beta lint"
-    stage: test
-    rust: beta
-    os: linux
-    script: .ci/lint.sh
-    if: branch = master AND tag IS blank
-
   #  _______        _   
   # |__   __|      | |  
   #    | | ___  ___| |_ 
@@ -71,13 +61,6 @@ matrix:
     rust: stable
     os: linux
     script: .ci/test.sh
-
-  - name: "beta test linux"
-    stage: test
-    rust: beta
-    os: linux
-    script: .ci/test.sh
-    if: branch = master AND tag IS blank
 
   - name: "stable test osx"
     rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for the alpha channel during generation, which was previously ignored
 
 ## [0.5.0] - 2019-09-13
 ### Added

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -839,7 +839,7 @@ impl Generator {
                                 for (cand_i, cand) in candidates.iter().enumerate() {
                                     k_neighs_to_color_pattern(
                                         &cand.k_neighs,
-                                        image::Rgb([0, 0, 0]),
+                                        image::Rgba([0, 0, 0, 255]),
                                         &example_maps,
                                         &mut candidates_patterns[cand_i],
                                         false,
@@ -850,7 +850,7 @@ impl Generator {
 
                                 k_neighs_to_color_pattern(
                                     &k_neighs_w_map_id, //feed into the function with always 0 index of the sample map
-                                    image::Rgb([0, 0, 0]),
+                                    image::Rgba([0, 0, 0, 255]),
                                     out_color_map,
                                     &mut my_pattern,
                                     is_tiling_mode,
@@ -862,7 +862,7 @@ impl Generator {
                                     for (cand_i, cand) in candidates.iter().enumerate() {
                                         k_neighs_to_color_pattern(
                                             &cand.k_neighs,
-                                            image::Rgb([0, 0, 0]),
+                                            image::Rgba([0, 0, 0, 255]),
                                             &in_guides.example_guides,
                                             &mut candidates_guide_patterns[cand_i],
                                             false,
@@ -871,7 +871,7 @@ impl Generator {
                                         //get example pattern to compare to
                                         k_neighs_to_color_pattern(
                                             &k_neighs_w_map_id,
-                                            image::Rgb([0, 0, 0]),
+                                            image::Rgba([0, 0, 0, 255]),
                                             &[in_guides.target_guide.clone()],
                                             &mut my_guide_pattern,
                                             is_tiling_mode,
@@ -969,12 +969,12 @@ impl Generator {
 
 fn k_neighs_to_color_pattern(
     k_neighs: &[(SignedCoord2D, MapId)],
-    outside_color: image::Rgb<u8>,
+    outside_color: image::Rgba<u8>,
     source_maps: &[ImageBuffer<'_>],
     pattern: &mut ColorPattern,
     is_wrap_mode: bool,
 ) {
-    pattern.0.resize(k_neighs.len() * 3, 0);
+    pattern.0.resize(k_neighs.len() * 4, 0);
     let mut i = 0;
 
     let wrap_dim = (
@@ -989,14 +989,14 @@ fn k_neighs_to_color_pattern(
             *n_coord
         };
 
-        let end = i + 3;
+        let end = i + 4;
 
         //check if he haven't gone outside the possible bounds
         if source_maps[n_map.0 as usize].is_in_bounds(coord) {
             pattern.0[i..end].copy_from_slice(
                 &(source_maps[n_map.0 as usize])
                     .get_pixel(coord.x as u32, coord.y as u32)
-                    .0[..3],
+                    .0[..4],
             )
         } else {
             // if we have gone out of bounds, then just fill as outside color

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -454,7 +454,7 @@ impl Generator {
         //divide by avg
         let avg: f64 = k_neighs_dist.iter().sum::<f64>() / (k_neighs_dist.len() as f64);
 
-        k_neighs_dist.iter_mut().for_each(|d| *d = *d / avg);
+        k_neighs_dist.iter_mut().for_each(|d| *d /= avg);
         k_neighs_dist
     }
 

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -442,17 +442,20 @@ impl Generator {
     fn get_distances_to_k_neighs(&self, coord: Coord2D, k_neighs_2d: &[SignedCoord2D]) -> Vec<f64> {
         let (dimx, dimy) = (f64::from(self.output_size.0), f64::from(self.output_size.1));
         let (x2, y2) = (f64::from(coord.x) / dimx, f64::from(coord.y) / dimy);
-        //since we will have 3 channels per pixel, duplicate 3 times each
-        let mut k_neighs_dist: Vec<f64> = Vec::new();
+        let mut k_neighs_dist: Vec<f64> = Vec::with_capacity(k_neighs_2d.len() * 4);
+
         for coord in k_neighs_2d.iter() {
             let (x1, y1) = ((f64::from(coord.x)) / dimx, (f64::from(coord.y)) / dimy);
             let dist = (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2);
-            k_neighs_dist.extend_from_slice(&[dist, dist, dist]);
+            // Duplicate the distance for each of our 4 channels
+            k_neighs_dist.extend_from_slice(&[dist, dist, dist, dist]);
         }
+
         //divide by avg
         let avg: f64 = k_neighs_dist.iter().sum::<f64>() / (k_neighs_dist.len() as f64);
 
-        k_neighs_dist.iter().map(|d| d / avg).collect()
+        k_neighs_dist.iter_mut().for_each(|d| *d = *d / avg);
+        k_neighs_dist
     }
 
     pub(crate) fn resolve_random_batch(

--- a/lib/tests/diff.rs
+++ b/lib/tests/diff.rs
@@ -157,14 +157,14 @@ macro_rules! diff_hash {
     };
 }
 
-diff_hash!(single_example, "JJNX6uGdGGnFx6j2Lm3ate6W", {
+diff_hash!(single_example, "JKc2MqWo1iNWeJ856Ty6+a1M", {
     ts::Session::builder()
         .add_example(&"../imgs/1.jpg")
         .seed(120)
         .output_size(100, 100)
 });
 
-diff_hash!(multi_example, "JC1qdVWNazxSMUzrrm5zfVrK", {
+diff_hash!(multi_example, "JFCWyK1a4vJ1eWNTQkPOmdy2", {
     ts::Session::builder()
         .add_examples(&[
             &"../imgs/multiexample/1.jpg",
@@ -178,7 +178,7 @@ diff_hash!(multi_example, "JC1qdVWNazxSMUzrrm5zfVrK", {
         .output_size(100, 100)
 });
 
-diff_hash!(guided, "JFaCExMXjofDKVVYWLBhRQUE", {
+diff_hash!(guided, "JBQFEQoXm5CCiWZUfHHBhweK", {
     ts::Session::builder()
         .add_example(
             ts::Example::builder(&"../imgs/2.jpg").with_guide(&"../imgs/masks/2_example.jpg"),
@@ -187,14 +187,14 @@ diff_hash!(guided, "JFaCExMXjofDKVVYWLBhRQUE", {
         .output_size(100, 100)
 });
 
-diff_hash!(style_transfer, "JFERMTUjG6OVpHGeL6ZpWd76", {
+diff_hash!(style_transfer, "JEMRDSUzJ4uhpHMes1Onenz0", {
     ts::Session::builder()
         .add_example(&"../imgs/multiexample/4.jpg")
         .load_target_guide(&"../imgs/tom.jpg")
         .output_size(100, 100)
 });
 
-diff_hash!(inpaint, "JNG1tkpSWMkqaucsxHEulykk", {
+diff_hash!(inpaint, "JNG1tl5SaIkqauco1NEmtikk", {
     ts::Session::builder()
         .inpaint_example(
             &"../imgs/masks/3_inpaint.jpg",
@@ -205,7 +205,7 @@ diff_hash!(inpaint, "JNG1tkpSWMkqaucsxHEulykk", {
         .output_size(100, 100)
 });
 
-diff_hash!(tiling, "JGZ10cmNaExhqYqtmlworRXS", {
+diff_hash!(tiling, "JFSVUUmMaMzhWSttmlwojR1q", {
     ts::Session::builder()
         .inpaint_example(
             &"../imgs/masks/1_tile.jpg",

--- a/lib/tests/diff.rs
+++ b/lib/tests/diff.rs
@@ -157,14 +157,14 @@ macro_rules! diff_hash {
     };
 }
 
-diff_hash!(single_example, "JKc2MqWo1iNWeJ856Ty6+a1M", {
+diff_hash!(single_example, "JJNX6uGdGGnFx6j2Lm3ate6W", {
     ts::Session::builder()
         .add_example(&"../imgs/1.jpg")
         .seed(120)
         .output_size(100, 100)
 });
 
-diff_hash!(multi_example, "JFCWyK1a4vJ1eWNTQkPOmdy2", {
+diff_hash!(multi_example, "JC1qdVWNazxSMUzrrm5zfVrK", {
     ts::Session::builder()
         .add_examples(&[
             &"../imgs/multiexample/1.jpg",
@@ -178,7 +178,7 @@ diff_hash!(multi_example, "JFCWyK1a4vJ1eWNTQkPOmdy2", {
         .output_size(100, 100)
 });
 
-diff_hash!(guided, "JBQFEgoXm5KCiWZUfHHBhyYK", {
+diff_hash!(guided, "JFaCExMXjofDKVVYWLBhRQUE", {
     ts::Session::builder()
         .add_example(
             ts::Example::builder(&"../imgs/2.jpg").with_guide(&"../imgs/masks/2_example.jpg"),
@@ -187,14 +187,14 @@ diff_hash!(guided, "JBQFEgoXm5KCiWZUfHHBhyYK", {
         .output_size(100, 100)
 });
 
-diff_hash!(style_transfer, "JEMRDSUzJ4uhpHMes1Onenz0", {
+diff_hash!(style_transfer, "JFERMTUjG6OVpHGeL6ZpWd76", {
     ts::Session::builder()
         .add_example(&"../imgs/multiexample/4.jpg")
         .load_target_guide(&"../imgs/tom.jpg")
         .output_size(100, 100)
 });
 
-diff_hash!(inpaint, "JNG1tl5SaIkqauco1NEmtikk", {
+diff_hash!(inpaint, "JNG1tkpSWMkqaucsxHEulykk", {
     ts::Session::builder()
         .inpaint_example(
             &"../imgs/masks/3_inpaint.jpg",
@@ -205,7 +205,7 @@ diff_hash!(inpaint, "JNG1tl5SaIkqauco1NEmtikk", {
         .output_size(100, 100)
 });
 
-diff_hash!(tiling, "JNSV0UiMaMzh2KotmlwojR2K", {
+diff_hash!(tiling, "JGZ10cmNaExhqYqtmlworRXS", {
     ts::Session::builder()
         .inpaint_example(
             &"../imgs/masks/1_tile.jpg",


### PR DESCRIPTION
Addressing #31 to support alpha channel as previously it was accepted as input but ignored during the generation. This fixes it, but makes output images not correspond to the same seed of the previous version. Might need to update our readme images (at some point 😝 )

Resolves: #31 