### PR TITLE
[ci] Set up mergify for automatic PR merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: automatic merge when CI passes and 1 reviews
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - status-success=Travis CI - Pull Request
+      - base=master
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: squash
+  - name: delete head branch after merge
+    conditions: []
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
Add mergify config file to enable PRs to automatically be merged in to master when they pass all checks, have an approved review and no outstanding changes requested or comments.

I've set it to squash PRs here as that is what we generally use. If this config works well here for this repo then I'll propagate it to `template-rust` and our other repos. 
