### PR TITLE
Replace `std::sync` locks with `parking_lot`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,6 +21,7 @@ exclude = ["/imgs"]
 
 [dependencies]
 crossbeam-utils = "0.6"
+parking_lot = "0.9"
 num_cpus = "1.10.1"
 rand = { version = "0.7.0", default-features = false } # avoid bringing in OS random gen that we don't use
 rand_pcg = "0.2.0"


### PR DESCRIPTION
... or don't. The outcome is inconclusive thus far.

@Jake-Shadle suggested trying `parking_lot` instead of `std::sync`, which would hopefully net us some performance wins. So far I'm getting mixed results:

`texture-synthesis --seed 1 --out out/01.jpg generate imgs/1.jpg`
* i7-5600U: 14.4 sec -> 15.8 sec (10% slower)
* TR 2990WX: 3.6 sec -> 3.35 sec (7% faster)
* Xeon W-2155: 3.02 sec -> 3.09 sec (2% slower)

`texture-synthesis --seed 1 --out out/01.jpg  --out-size 1024x1024 generate imgs/1.jpg`
* i7-5600U: 65.5 sec -> 71.3 sec (9% slower)
* TR 2990WX: 15.7 sec -> 14.1 sec (11% faster)
* Xeon W-2155: 13.8 sec -> 14.2 sec (3% slower)