### PR TITLE
Inpaint size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for the alpha channel during generation, which was previously ignored
 
+### Changed
+- `SessionBuilder::inpaint_example` now requires a size be provided by which all inputs will be
+resized, as well setting the output image size. Previously, you had to manually specify matching
+`output_size` and `resize_input` otherwise you would get a parameter validation error.
+- All public methods/functions that took a size either as 2 u32's, or a tuple of them, now use
+a simple `Dims` struct for clarity.
+
 ### Fixed
 - [PR#36](https://github.com/EmbarkStudios/texture-synthesis/pull/36) Fixed undefined behavior in `Generator::update`. Thanks for reporting, [@ralfbiedert](https://github.com/ralfbiedert)!
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ fn main() -> Result<(), ts::Error> {
         // we can ensure all of them come with same size
         // that is however optional, the generator doesnt care whether all images are same sizes
         // however, if you have guides or other additional maps, those have to be same size(s) as corresponding example(s)
-        .resize_input(300, 300)
+        .resize_input(ts::Dims {
+            width: 300,
+            height: 300,
+        })
         // randomly initialize first 10 pixels
         .random_init(10)
         .seed(211)
@@ -93,7 +96,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --rand-init 10 --seed 211 --in-size 300 -o out/02.png --debug-out-dir out generate imgs/multiexample/1.jpg imgs/multiexample/2.jpg imgs/multiexample/3.jpg imgs/multiexample/4.jpg`
+`cargo run --release -- --rand-init 10 --seed 211 --in-size 300x300 -o out/02.png --debug-out-dir out generate imgs/multiexample/1.jpg imgs/multiexample/2.jpg imgs/multiexample/3.jpg imgs/multiexample/4.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/tbz5d57.jpg" width="600" height="364">
@@ -199,10 +202,14 @@ fn main() -> Result<(), ts::Error> {
                 // would then need at least 1 other example image to actually source from
                 // example.set_sample_method(ts::SampleMethod::Ignore);
                 .set_sample_method(&"imgs/masks/3_inpaint.jpg"),
+            // Inpaint requires that inputs and outputs be the same size, so it's a required
+            // parameter that overrides both `resize_input` and `output_size`
+            ts::Dims::square(400),
         )
-        // during inpaint, it is important to ensure both input and output are the same size
-        .resize_input(400, 400)
-        .output_size(400, 400)
+        // Ignored
+        .resize_input(ts::Dims::square(200))
+        // Ignored
+        .output_size(ts::Dims::square(100))
         .build()?;
 
     let generated = texsynth.run(None);
@@ -214,7 +221,9 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --in-size 400 --out-size 400 --inpaint imgs/masks/3_inpaint.jpg -o out/05.png generate imgs/3.jpg`
+Note that the `--out-size` parameter determines the size for all inputs and outputs when using inpaint!
+
+`cargo run --release -- --out-size 400 --inpaint imgs/masks/3_inpaint.jpg -o out/05.png generate imgs/3.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/WZm2HHL.jpg" width="600" height="364">
@@ -238,10 +247,11 @@ fn main() -> Result<(), ts::Error> {
 
     let texsynth = ts::Session::builder()
         // load a mask that specifies borders of the image we can modify to make it tiling
-        .inpaint_example(&"imgs/masks/1_tile.jpg", ts::Example::new(&"imgs/1.jpg"))
-        //ensure correct sizes
-        .resize_input(400, 400)
-        .output_size(400, 400)
+        .inpaint_example(
+            &"imgs/masks/1_tile.jpg",
+            ts::Example::new(&"imgs/1.jpg"),
+            ts::Dims::square(400),
+        )
         //turn on tiling mode!
         .tiling_mode(true)
         .build()?;
@@ -254,7 +264,7 @@ fn main() -> Result<(), ts::Error> {
 
 #### CLI
 
-`cargo run --release -- --inpaint imgs/masks/1_tile.jpg --in-size 400 --out-size 400 --tiling -o out/06.bmp generate imgs/1.jpg`
+`cargo run --release -- --inpaint imgs/masks/1_tile.jpg --out-size 400 --tiling -o out/06.bmp generate imgs/1.jpg`
 
 You should get the following result with the images provided in this repo:
 <img src="https://i.imgur.com/foSlREz.jpg" width="600" height="364">

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -364,13 +364,13 @@ impl ProgressWindow {
     #[cfg(feature = "progress")]
     fn with_preview(
         mut self,
-        size: (u32, u32),
+        size: Dims,
         update_every: std::time::Duration,
     ) -> Result<Self, Error> {
         let window = Window::new(
             "Texture Synthesis",
-            size.0 as usize,
-            size.1 as usize,
+            size.width as usize,
+            size.height as usize,
             minifb::WindowOptions::default(),
         )
         .unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,18 +2,19 @@ use structopt::StructOpt;
 
 use std::path::PathBuf;
 use texture_synthesis::{
-    image::ImageOutputFormat as ImgFmt, Error, Example, ImageSource, SampleMethod, Session,
+    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, SampleMethod, Session,
 };
 
-fn parse_size(input: &str) -> Result<(u32, u32), std::num::ParseIntError> {
+fn parse_size(input: &str) -> Result<Dims, std::num::ParseIntError> {
     let mut i = input.splitn(2, 'x');
 
-    let x: u32 = i.next().unwrap_or("").parse()?;
-    let y: u32 = match i.next() {
+    let width: u32 = i.next().unwrap_or("").parse()?;
+    let height: u32 = match i.next() {
         Some(num) => num.parse()?,
-        None => x,
+        None => width,
     };
-    Ok((x, y))
+
+    Ok(Dims { width, height })
 }
 
 fn parse_img_fmt(input: &str) -> Result<ImgFmt, String> {
@@ -140,7 +141,7 @@ struct Opt {
         default_value = "500",
         parse(try_from_str = parse_size)
     )]
-    out_size: (u32, u32),
+    out_size: Dims,
     /// Output format detection when writing to a file is based on the extension, but when
     /// writing to stdout by passing `-` you must specify the format if you want something
     /// other than the default.
@@ -152,7 +153,7 @@ struct Opt {
     stdout_fmt: ImgFmt,
     /// Resize input example map(s), in `width x height`, or a single number for both dimensions
     #[structopt(long, parse(try_from_str = parse_size))]
-    in_size: Option<(u32, u32)>,
+    in_size: Option<Dims>,
     /// The path to save the generated image to, the file extensions of the path determines
     /// the image format used. You may use `-` for stdout.
     #[structopt(long = "out", short, parse(from_os_str))]
@@ -250,7 +251,7 @@ fn real_main() -> Result<(), Error> {
 
     sb = sb
         .add_examples(examples)
-        .output_size(args.out_size.0, args.out_size.1)
+        .output_size(args.out_size)
         .seed(args.tweaks.seed.unwrap_or_default())
         .nearest_neighbors(args.tweaks.k_neighbors)
         .random_sample_locations(args.tweaks.m_rand)
@@ -273,7 +274,7 @@ fn real_main() -> Result<(), Error> {
     }
 
     if let Some(insize) = args.in_size {
-        sb = sb.resize_input(insize.0, insize.1);
+        sb = sb.resize_input(insize);
     }
 
     let session = sb.build()?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -246,7 +246,7 @@ fn real_main() -> Result<(), Error> {
             inpaint_example.set_sample_method(inpaint);
         }
 
-        sb = sb.inpaint_example(inpaint, inpaint_example);
+        sb = sb.inpaint_example(inpaint, inpaint_example, args.out_size);
     }
 
     sb = sb

--- a/lib/examples/02_multi_example_synthesis.rs
+++ b/lib/examples/02_multi_example_synthesis.rs
@@ -13,7 +13,10 @@ fn main() -> Result<(), ts::Error> {
         // we can ensure all of them come with same size
         // that is however optional, the generator doesnt care whether all images are same sizes
         // however, if you have guides or other additional maps, those have to be same size(s) as corresponding example(s)
-        .resize_input(ts::Dims::square(300))
+        .resize_input(ts::Dims {
+            width: 300,
+            height: 300,
+        })
         // randomly initialize first 10 pixels
         .random_init(10)
         .seed(211)

--- a/lib/examples/02_multi_example_synthesis.rs
+++ b/lib/examples/02_multi_example_synthesis.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), ts::Error> {
         // we can ensure all of them come with same size
         // that is however optional, the generator doesnt care whether all images are same sizes
         // however, if you have guides or other additional maps, those have to be same size(s) as corresponding example(s)
-        .resize_input(300, 300)
+        .resize_input(ts::Dims::square(300))
         // randomly initialize first 10 pixels
         .random_init(10)
         .seed(211)

--- a/lib/examples/05_inpaint.rs
+++ b/lib/examples/05_inpaint.rs
@@ -15,10 +15,8 @@ fn main() -> Result<(), ts::Error> {
                 // would then need at least 1 other example image to actually source from
                 // example.set_sample_method(ts::SampleMethod::Ignore);
                 .set_sample_method(&"imgs/masks/3_inpaint.jpg"),
+            ts::Dims::square(400),
         )
-        // during inpaint, it is important to ensure both input and output are the same size
-        .resize_input(400, 400)
-        .output_size(400, 400)
         .build()?;
 
     let generated = texsynth.run(None);

--- a/lib/examples/05_inpaint.rs
+++ b/lib/examples/05_inpaint.rs
@@ -15,8 +15,14 @@ fn main() -> Result<(), ts::Error> {
                 // would then need at least 1 other example image to actually source from
                 // example.set_sample_method(ts::SampleMethod::Ignore);
                 .set_sample_method(&"imgs/masks/3_inpaint.jpg"),
+            // Inpaint requires that inputs and outputs be the same size, so it's a required
+            // parameter that overrides both `resize_input` and `output_size`
             ts::Dims::square(400),
         )
+        // Ignored
+        .resize_input(ts::Dims::square(200))
+        // Ignored
+        .output_size(ts::Dims::square(100))
         .build()?;
 
     let generated = texsynth.run(None);

--- a/lib/examples/06_tiling_texture.rs
+++ b/lib/examples/06_tiling_texture.rs
@@ -8,10 +8,11 @@ fn main() -> Result<(), ts::Error> {
 
     let texsynth = ts::Session::builder()
         // load a mask that specifies borders of the image we can modify to make it tiling
-        .inpaint_example(&"imgs/masks/1_tile.jpg", ts::Example::new(&"imgs/1.jpg"))
-        //ensure correct sizes
-        .resize_input(400, 400)
-        .output_size(400, 400)
+        .inpaint_example(
+            &"imgs/masks/1_tile.jpg",
+            ts::Example::new(&"imgs/1.jpg"),
+            ts::Dims::square(400),
+        )
         //turn on tiling mode!
         .tiling_mode(true)
         .build()?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -368,7 +368,7 @@ where
 pub struct SessionBuilder<'a> {
     examples: Vec<Example<'a>>,
     target_guide: Option<ImageSource<'a>>,
-    inpaint_mask: Option<(ImageSource<'a>, usize)>,
+    inpaint_mask: Option<(ImageSource<'a>, usize, Dims)>,
     params: Parameters,
 }
 
@@ -413,7 +413,10 @@ impl<'a> SessionBuilder<'a> {
         self
     }
 
-    /// Inpaints an example.
+    /// Inpaints an example. Due to how inpainting works, a size must also be provided, as
+    /// all examples, as well as the inpaint mask, must be the same size as each other, as
+    /// well as the final output image. Using `resize_input` or `output_size` is ignored
+    /// if this method is called.
     ///
     /// To prevent sampling from the example, you can specify `SamplingMethod::Ignore` with `Example::set_sample_method`.
     ///
@@ -429,7 +432,8 @@ impl<'a> SessionBuilder<'a> {
     ///         // This will prevent sampling from the imgs/2.jpg, note that
     ///         // we *MUST* provide at least one example to source from!
     ///         texture_synthesis::Example::builder(&"imgs/2.jpg")
-    ///             .set_sample_method(texture_synthesis::SampleMethod::Ignore)
+    ///             .set_sample_method(texture_synthesis::SampleMethod::Ignore),
+    ///         texture_synthesis::Dims::square(400)
     ///     )
     ///     .build().expect("failed to build session");
     /// ```
@@ -437,8 +441,9 @@ impl<'a> SessionBuilder<'a> {
         mut self,
         inpaint_mask: I,
         example: E,
+        size: Dims,
     ) -> Self {
-        self.inpaint_mask = Some((inpaint_mask.into(), self.examples.len()));
+        self.inpaint_mask = Some((inpaint_mask.into(), self.examples.len(), size));
         self.examples.push(example.into());
         self
     }
@@ -555,9 +560,33 @@ impl<'a> SessionBuilder<'a> {
         self.check_parameters_validity()?;
         self.check_images_validity()?;
 
+        struct InpaintExample {
+            inpaint_mask: image::RgbaImage,
+            color_map: image::RgbaImage,
+            example_index: usize,
+        }
+
+        let (inpaint, out_size, in_size) = match self.inpaint_mask {
+            Some((src, ind, size)) => {
+                let inpaint_mask = load_image(src, Some(size))?;
+                let color_map = load_image(self.examples[ind].img.clone(), Some(size))?;
+
+                (
+                    Some(InpaintExample {
+                        inpaint_mask,
+                        color_map,
+                        example_index: ind,
+                    }),
+                    size,
+                    Some(size),
+                )
+            }
+            None => (None, self.params.output_size, self.params.resize_input),
+        };
+
         let target_guide = match self.target_guide {
             Some(tg) => {
-                let tg_img = load_image(tg, Some(self.params.output_size))?;
+                let tg_img = load_image(tg, Some(out_size))?;
 
                 let num_guides = self.examples.iter().filter(|ex| ex.guide.is_some()).count();
                 let tg_img = if num_guides == 0 {
@@ -574,29 +603,6 @@ impl<'a> SessionBuilder<'a> {
             None => None,
         };
 
-        struct InpaintExample {
-            inpaint_mask: image::RgbaImage,
-            color_map: image::RgbaImage,
-            example_index: usize,
-        }
-
-        let inpaint = match self.inpaint_mask {
-            Some((src, ind)) => {
-                let inpaint_mask = load_image(src, Some(self.params.output_size))?;
-                let color_map = load_image(
-                    self.examples[ind].img.clone(),
-                    Some(self.params.output_size),
-                )?;
-
-                Some(InpaintExample {
-                    inpaint_mask,
-                    color_map,
-                    example_index: ind,
-                })
-            }
-            None => None,
-        };
-
         let example_len = self.examples.len();
 
         let mut examples = Vec::with_capacity(example_len);
@@ -608,11 +614,7 @@ impl<'a> SessionBuilder<'a> {
         let mut methods = Vec::with_capacity(example_len);
 
         for example in self.examples {
-            let resolved = example.resolve(
-                self.params.backtrack_stages,
-                self.params.resize_input,
-                &target_guide,
-            )?;
+            let resolved = example.resolve(self.params.backtrack_stages, in_size, &target_guide)?;
 
             examples.push(resolved.image);
 
@@ -625,9 +627,9 @@ impl<'a> SessionBuilder<'a> {
 
         // Initialize generator based on availability of an inpaint_mask.
         let generator = match inpaint {
-            None => Generator::new(self.params.output_size),
+            None => Generator::new(out_size),
             Some(inpaint) => Generator::new_from_inpaint(
-                self.params.output_size,
+                out_size,
                 inpaint.inpaint_mask,
                 inpaint.color_map,
                 inpaint.example_index,
@@ -683,17 +685,6 @@ impl<'a> SessionBuilder<'a> {
                     max: 1024.0,
                     value: max_count as f32,
                     name: "max_thread_count",
-                }));
-            }
-        }
-
-        if self.inpaint_mask.is_some() {
-            let input = self.params.resize_input.unwrap_or_else(|| (0, 0));
-
-            if input.0 != self.params.output_size.0 || input.1 != self.params.output_size.1 {
-                return Err(Error::SizeMismatch(errors::SizeMismatch {
-                    input,
-                    output: self.params.output_size,
                 }));
             }
         }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{Dims, Error};
 use std::path::Path;
 
 /// Helper type used to pass image data to the Session
@@ -31,7 +31,7 @@ where
 
 pub(crate) fn load_image(
     src: ImageSource<'_>,
-    resize: Option<(u32, u32)>,
+    resize: Option<Dims>,
 ) -> Result<image::RgbaImage, Error> {
     let img = match src {
         ImageSource::Memory(data) => image::load_from_memory(data),
@@ -44,8 +44,13 @@ pub(crate) fn load_image(
         Some(ref size) => {
             use image::GenericImageView;
 
-            if img.width() != size.0 || img.height() != size.1 {
-                image::imageops::resize(&img.to_rgba(), size.0, size.1, image::imageops::CatmullRom)
+            if img.width() != size.width || img.height() != size.height {
+                image::imageops::resize(
+                    &img.to_rgba(),
+                    size.width,
+                    size.height,
+                    image::imageops::CatmullRom,
+                )
             } else {
                 img.to_rgba()
             }
@@ -55,15 +60,15 @@ pub(crate) fn load_image(
 
 pub(crate) fn transform_to_guide_map(
     image: image::RgbaImage,
-    size: Option<(u32, u32)>,
+    size: Option<Dims>,
     blur_sigma: f32,
 ) -> image::RgbaImage {
     use image::GenericImageView;
     let dyn_img = image::DynamicImage::ImageRgba8(image);
 
     if let Some(s) = size {
-        if dyn_img.width() != s.0 || dyn_img.height() != s.1 {
-            dyn_img.resize(s.0, s.1, image::imageops::Triangle);
+        if dyn_img.width() != s.width || dyn_img.height() != s.height {
+            dyn_img.resize(s.width, s.height, image::imageops::Triangle);
         }
     }
 

--- a/lib/tests/diff.rs
+++ b/lib/tests/diff.rs
@@ -1,5 +1,6 @@
 use img_hash::{HashType, ImageHash};
 use texture_synthesis as ts;
+use ts::Dims;
 
 // The tests below each run the different example code we have and
 // compare the image hash against a "known good" hash. The test
@@ -161,7 +162,7 @@ diff_hash!(single_example, "JKc2MqWo1iNWeJ856Ty6+a1M", {
     ts::Session::builder()
         .add_example(&"../imgs/1.jpg")
         .seed(120)
-        .output_size(100, 100)
+        .output_size(Dims::square(100))
 });
 
 diff_hash!(multi_example, "JFCWyK1a4vJ1eWNTQkPOmdy2", {
@@ -172,10 +173,10 @@ diff_hash!(multi_example, "JFCWyK1a4vJ1eWNTQkPOmdy2", {
             &"../imgs/multiexample/3.jpg",
             &"../imgs/multiexample/4.jpg",
         ])
-        .resize_input(100, 100)
+        .resize_input(Dims::square(100))
         .random_init(10)
         .seed(211)
-        .output_size(100, 100)
+        .output_size(Dims::square(100))
 });
 
 diff_hash!(guided, "JBQFEQoXm5CCiWZUfHHBhweK", {
@@ -184,14 +185,14 @@ diff_hash!(guided, "JBQFEQoXm5CCiWZUfHHBhweK", {
             ts::Example::builder(&"../imgs/2.jpg").with_guide(&"../imgs/masks/2_example.jpg"),
         )
         .load_target_guide(&"../imgs/masks/2_target.jpg")
-        .output_size(100, 100)
+        .output_size(Dims::square(100))
 });
 
 diff_hash!(style_transfer, "JEMRDSUzJ4uhpHMes1Onenz0", {
     ts::Session::builder()
         .add_example(&"../imgs/multiexample/4.jpg")
         .load_target_guide(&"../imgs/tom.jpg")
-        .output_size(100, 100)
+        .output_size(Dims::square(100))
 });
 
 diff_hash!(inpaint, "JNG1tl5SaIkqauco1NEmtikk", {

--- a/lib/tests/diff.rs
+++ b/lib/tests/diff.rs
@@ -196,14 +196,14 @@ diff_hash!(style_transfer, "JEMRDSUzJ4uhpHMes1Onenz0", {
 });
 
 diff_hash!(inpaint, "JNG1tl5SaIkqauco1NEmtikk", {
-    ts::Session::builder()
-        .inpaint_example(
-            &"../imgs/masks/3_inpaint.jpg",
-            ts::Example::builder(&"../imgs/3.jpg")
-                .set_sample_method(&"../imgs/masks/3_inpaint.jpg"),
-        )
-        .resize_input(100, 100)
-        .output_size(100, 100)
+    ts::Session::builder().inpaint_example(
+        &"../imgs/masks/3_inpaint.jpg",
+        ts::Example::builder(&"../imgs/3.jpg").set_sample_method(&"../imgs/masks/3_inpaint.jpg"),
+        Dims {
+            width: 100,
+            height: 100,
+        },
+    )
 });
 
 diff_hash!(tiling, "JFSVUUmMaMzhWSttmlwojR1q", {
@@ -211,8 +211,10 @@ diff_hash!(tiling, "JFSVUUmMaMzhWSttmlwojR1q", {
         .inpaint_example(
             &"../imgs/masks/1_tile.jpg",
             ts::Example::new(&"../imgs/1.jpg"),
+            Dims {
+                width: 100,
+                height: 100,
+            },
         )
-        .resize_input(100, 100)
-        .output_size(100, 100)
         .tiling_mode(true)
 });


### PR DESCRIPTION
* Changes inpaint_example to include a size argument, which is used to specify both the input and output size
* Replace the use of tuples/loose u32's with a small Dims struct.