### PR TITLE
[ci] Remove master condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ stages:
 - test
 # Deploy stage on runs on a valid semver tag
 - name: deploy
-  if: branch = master AND tag =~ /^\d+\.\d+\.\d+.*$/
+  if: tag =~ /^\d+\.\d+\.\d+.*$/
 
 env:
   global:


### PR DESCRIPTION
Travis is not triggering deployments when tags are pushed to master, like it should. so remove the condition to keep it how it was, we can push tags to master once a release is on master.