### PR TITLE
Add --flips-and-rotates flag

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,8 +5,8 @@ use structopt::StructOpt;
 
 use std::path::PathBuf;
 use texture_synthesis::{
-    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, SampleMethod, Session,
-    Transformation,
+    image::ImageOutputFormat as ImgFmt, load_dynamic_image, Dims, Error, Example, ImageSource,
+    SampleMethod, Session,
 };
 
 fn parse_size(input: &str) -> Result<Dims, std::num::ParseIntError> {
@@ -243,36 +243,16 @@ fn real_main() -> Result<(), Error> {
             }
 
             let mut transformed_examples: Vec<_> = vec![];
-            for example in &examples {
+            for example_path in &fr.examples {
+                let base_image = load_dynamic_image(example_path.into())?;
                 let mut new_examples: Vec<_> = vec![
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::FlipH])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::Rot90])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::FlipH, Transformation::Rot90])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::Rot180])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::FlipH, Transformation::Rot180])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::Rot270])
-                        .clone(),
-                    example
-                        .clone()
-                        .with_transformations(vec![Transformation::FlipH, Transformation::Rot270])
-                        .clone(),
+                    Example::new(base_image.fliph()),
+                    Example::new(base_image.rotate90()),
+                    Example::new(base_image.fliph().rotate90()),
+                    Example::new(base_image.rotate180()),
+                    Example::new(base_image.fliph().rotate180()),
+                    Example::new(base_image.rotate270()),
+                    Example::new(base_image.fliph().rotate270()),
                 ];
                 transformed_examples.append(&mut new_examples);
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,8 @@ use structopt::StructOpt;
 
 use std::path::PathBuf;
 use texture_synthesis::{
-    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, SampleMethod, Session, Transformation,
+    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, SampleMethod, Session,
+    Transformation,
 };
 
 fn parse_size(input: &str) -> Result<Dims, std::num::ParseIntError> {
@@ -220,13 +221,43 @@ fn real_main() -> Result<(), Error> {
                 let mut transformed_examples: Vec<_> = vec![];
                 for example in &examples {
                     let mut new_examples: Vec<_> = vec![
-                        example.clone().with_transformations(vec![Transformation::FlipH]).clone(),
-                        example.clone().with_transformations(vec![Transformation::Rot90]).clone(),
-                        example.clone().with_transformations(vec![Transformation::FlipH, Transformation::Rot90]).clone(),
-                        example.clone().with_transformations(vec![Transformation::Rot180]).clone(),
-                        example.clone().with_transformations(vec![Transformation::FlipH, Transformation::Rot180]).clone(),
-                        example.clone().with_transformations(vec![Transformation::Rot270]).clone(),
-                        example.clone().with_transformations(vec![Transformation::FlipH, Transformation::Rot270]).clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![Transformation::FlipH])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![Transformation::Rot90])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![
+                                Transformation::FlipH,
+                                Transformation::Rot90,
+                            ])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![Transformation::Rot180])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![
+                                Transformation::FlipH,
+                                Transformation::Rot180,
+                            ])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![Transformation::Rot270])
+                            .clone(),
+                        example
+                            .clone()
+                            .with_transformations(vec![
+                                Transformation::FlipH,
+                                Transformation::Rot270,
+                            ])
+                            .clone(),
                     ];
                     transformed_examples.append(&mut new_examples);
                 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -238,7 +238,6 @@ impl AsRef<image::RgbaImage> for GeneratedImage {
 }
 
 /// Method used for sampling an example image.
-#[derive(Clone)]
 pub enum GenericSampleMethod<Img> {
     /// All pixels in the example image can be sampled.
     All,
@@ -316,7 +315,6 @@ impl<'a> Into<Example<'a>> for ExampleBuilder<'a> {
 }
 
 /// An example to be used in texture generation
-#[derive(Clone)]
 pub struct Example<'a> {
     img: ImageSource<'a>,
     guide: Option<ImageSource<'a>>,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -378,7 +378,10 @@ impl<'a> Example<'a> {
         resize: Option<Dims>,
         target_guide: &Option<ImagePyramid>,
     ) -> Result<ResolvedExample, Error> {
-        let image = ImagePyramid::new(load_image(self.img, resize, self.transformations)?, Some(backtracks));
+        let image = ImagePyramid::new(
+            load_image(self.img, resize, self.transformations)?,
+            Some(backtracks),
+        );
 
         let guide = match target_guide {
             Some(tg) => {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,21 +1,6 @@
 use crate::{Dims, Error};
 use std::path::Path;
 
-/// Helper type used to transform image sources
-#[derive(Clone)]
-pub enum Transformation {
-    /// Flips an image horizontally
-    FlipH,
-    /// Flips an image vertically
-    FlipV,
-    /// Rotates the image by 90 degrees (clockwise)
-    Rot90,
-    /// Rotates the image by 180 degrees (clockwise)
-    Rot180,
-    /// Rotates the image by 270 degrees (clockwise)
-    Rot270,
-}
-
 /// Helper type used to pass image data to the Session
 #[derive(Clone)]
 pub enum ImageSource<'a> {
@@ -44,9 +29,7 @@ where
     }
 }
 
-pub(crate) fn get_dynamic_image(
-    src: ImageSource<'_>,
-) -> Result<image::DynamicImage, image::ImageError> {
+pub fn load_dynamic_image(src: ImageSource<'_>) -> Result<image::DynamicImage, image::ImageError> {
     match src {
         ImageSource::Memory(data) => image::load_from_memory(data),
         ImageSource::Path(path) => image::open(path),
@@ -57,18 +40,8 @@ pub(crate) fn get_dynamic_image(
 pub(crate) fn load_image(
     src: ImageSource<'_>,
     resize: Option<Dims>,
-    transformations: Vec<Transformation>,
 ) -> Result<image::RgbaImage, Error> {
-    let mut img = get_dynamic_image(src)?;
-    for t in transformations {
-        match t {
-            Transformation::FlipH => img = img.fliph(),
-            Transformation::FlipV => img = img.flipv(),
-            Transformation::Rot90 => img = img.rotate90(),
-            Transformation::Rot180 => img = img.rotate180(),
-            Transformation::Rot270 => img = img.rotate270(),
-        }
-    }
+    let img = load_dynamic_image(src)?;
     Ok(match resize {
         None => img.to_rgba(),
         Some(ref size) => {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -47,11 +47,11 @@ where
 pub(crate) fn get_dynamic_image(
     src: ImageSource<'_>,
 ) -> Result<image::DynamicImage, image::ImageError> {
-    return match src {
+    match src {
         ImageSource::Memory(data) => image::load_from_memory(data),
         ImageSource::Path(path) => image::open(path),
         ImageSource::Image(img) => Ok(img),
-    };
+    }
 }
 
 pub(crate) fn load_image(


### PR DESCRIPTION
Adds a `--flips-and-rotates` flag. Closes #30

Here's the original output of `cargo run --release -- --out /tmp/out.png generate imgs/tom.jpg`:

![original](https://user-images.githubusercontent.com/1187242/66705359-75574980-ed1d-11e9-8c1e-f88e2550e8d0.png)

And here's with `--flips-and-rotates`:

![flip-rotate](https://user-images.githubusercontent.com/1187242/66705360-8011de80-ed1d-11e9-91dc-4cbfd8efab6d.png)

I'm pretty new with Rust and I'm not sure how to write tests for this/validate that the output is correct. Sorry for any dumb mistake 🙇.