### PR TITLE
Add `--inpaint-alpha` to CLI and API changes to derive mask from channels

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,8 @@ use structopt::StructOpt;
 
 use std::path::PathBuf;
 use texture_synthesis::{
-    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, SampleMethod, Session,
+    image::ImageOutputFormat as ImgFmt, Dims, Error, Example, ImageSource, Mask, SampleMethod,
+    Session,
 };
 
 fn parse_size(input: &str) -> Result<Dims, std::num::ParseIntError> {
@@ -138,6 +139,9 @@ struct Opt {
     /// Path to an inpaint map image, where black pixels are resolved, and white pixels are kept
     #[structopt(long, parse(from_os_str))]
     inpaint: Option<PathBuf>,
+    /// Flag to extract inpaint from the example's alpha channel
+    #[structopt(long)]
+    inpaint_alpha: bool,
     /// Size of the generated image, in `width x height`, or a single number for both dimensions
     #[structopt(
         long,
@@ -230,7 +234,7 @@ fn real_main() -> Result<(), Error> {
             match mask.as_str() {
                 "ALL" => example.set_sample_method(SampleMethod::All),
                 "IGNORE" => example.set_sample_method(SampleMethod::Ignore),
-                path => example.set_sample_method(SampleMethod::Image(ImageSource::Path(
+                path => example.set_sample_method(SampleMethod::Image(ImageSource::from_path(
                     &std::path::Path::new(path),
                 ))),
             };
@@ -238,6 +242,16 @@ fn real_main() -> Result<(), Error> {
     }
 
     let mut sb = Session::builder();
+
+    if args.inpaint_alpha {
+        let mut inpaint_example = examples.remove(0);
+        let inpaint = inpaint_example.image_source().clone().mask(Mask::A);
+        if args.sample_masks.is_empty() {
+            inpaint_example.set_sample_method(SampleMethod::Image(inpaint.clone()));
+        }
+
+        sb = sb.inpaint_example(inpaint, inpaint_example, args.out_size);
+    }
 
     // TODO: Make inpaint work with multiple examples
     if let Some(ref inpaint) = args.inpaint {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -141,7 +141,7 @@ struct Opt {
     inpaint: Option<PathBuf>,
     /// Flag to extract inpaint from the example's alpha channel
     #[structopt(long)]
-    inpaint_alpha: bool,
+    inpaint_channel: Option<Mask>,
     /// Size of the generated image, in `width x height`, or a single number for both dimensions
     #[structopt(
         long,
@@ -243,18 +243,21 @@ fn real_main() -> Result<(), Error> {
 
     let mut sb = Session::builder();
 
-    if args.inpaint_alpha {
+    // TODO: Make inpaint work with multiple examples
+    if let (Some(_), Some(_)) = (args.inpaint_channel, &args.inpaint) {
+        return Err(Error::UnsupportedArgPair(
+            "channel".to_owned(),
+            "inpaint".to_owned(),
+        ));
+    } else if let Some(channel) = args.inpaint_channel {
         let mut inpaint_example = examples.remove(0);
-        let inpaint = inpaint_example.image_source().clone().mask(Mask::A);
+        let inpaint = inpaint_example.image_source().clone().mask(channel);
         if args.sample_masks.is_empty() {
             inpaint_example.set_sample_method(SampleMethod::Image(inpaint.clone()));
         }
 
         sb = sb.inpaint_example(inpaint, inpaint_example, args.out_size);
-    }
-
-    // TODO: Make inpaint work with multiple examples
-    if let Some(ref inpaint) = args.inpaint {
+    } else if let Some(ref inpaint) = args.inpaint {
         let mut inpaint_example = examples.remove(0);
 
         // If the user hasn't explicitly specified sample masks, assume they

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -56,6 +56,10 @@ pub enum Error {
     NoExamples,
     ///
     MapsCountMismatch(u32, u32),
+    /// An invalid string has that can't be parsed into a `Mask`
+    ParseMask(String),
+    /// The user specified an unsupported pair of arguments
+    UnsupportedArgPair(String, String),
 }
 
 impl fmt::Display for Error {
@@ -91,6 +95,16 @@ impl fmt::Display for Error {
                 f,
                 "{} map(s) were provided, but {} is/are required",
                 input, required
+            ),
+            Self::ParseMask(mask_string) => write!(
+                f,
+                "couldn't parse mask '{}', not one of: 'r', 'g', 'b', 'a'",
+                mask_string
+            ),
+            Self::UnsupportedArgPair(arg_a, arg_b) => write!(
+                f,
+                "the arguments '{}' and '{}' can't be used together, pick one of them",
+                arg_a, arg_b,
             ),
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -54,7 +54,7 @@ use std::path::Path;
 mod unsync;
 
 pub use image;
-pub use utils::ImageSource;
+pub use utils::{DataSource, ImageSource, Mask};
 
 pub use errors::Error;
 
@@ -325,7 +325,9 @@ impl<'a> Example<'a> {
     pub fn builder<I: Into<ImageSource<'a>>>(img: I) -> ExampleBuilder<'a> {
         ExampleBuilder::new(img)
     }
-
+    pub fn image_source(&self) -> &ImageSource<'a> {
+        &self.img
+    }
     /// Creates a new example input from the specified image source
     pub fn new<I: Into<ImageSource<'a>>>(img: I) -> Self {
         Self {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -3,7 +3,28 @@ use std::path::Path;
 
 /// Helper type used to pass image data to the Session
 #[derive(Clone)]
-pub enum ImageSource<'a> {
+pub struct ImageSource<'a> {
+    data_source: DataSource<'a>,
+    mask: Option<Mask>,
+}
+
+impl<'a> ImageSource<'a> {
+    pub fn from_path(path: &'a Path) -> ImageSource<'a> {
+        ImageSource {
+            data_source: DataSource::Path(path),
+            mask: None,
+        }
+    }
+
+    pub fn mask(mut self, mask: Mask) -> ImageSource<'a> {
+        self.mask = Some(mask);
+        self
+    }
+}
+
+/// Helper type used to define the source of `ImageSource`'s data
+#[derive(Clone)]
+pub enum DataSource<'a> {
     /// A raw buffer of image data, see `image::load_from_memory` for details
     /// on what is supported
     Memory(&'a [u8]),
@@ -14,9 +35,9 @@ pub enum ImageSource<'a> {
     Image(image::DynamicImage),
 }
 
-impl<'a> From<image::DynamicImage> for ImageSource<'a> {
+impl<'a> From<image::DynamicImage> for DataSource<'a> {
     fn from(img: image::DynamicImage) -> Self {
-        ImageSource::Image(img)
+        DataSource::Image(img)
     }
 }
 
@@ -25,7 +46,39 @@ where
     S: AsRef<Path> + 'a,
 {
     fn from(path: &'a S) -> Self {
+        Self {
+            data_source: DataSource::Path(path.as_ref()),
+            mask: None,
+        }
+    }
+}
+
+impl<'a, S> From<&'a S> for DataSource<'a>
+where
+    S: AsRef<Path> + 'a,
+{
+    fn from(path: &'a S) -> Self {
         Self::Path(path.as_ref())
+    }
+}
+
+/// Helper type used to mask `ImageSource`'s channels
+#[derive(Clone)]
+pub enum Mask {
+    R,
+    G,
+    B,
+    A,
+}
+
+impl From<&Mask> for usize {
+    fn from(mask: &Mask) -> Self {
+        match mask {
+            Mask::R => 0,
+            Mask::G => 1,
+            Mask::B => 2,
+            Mask::A => 3,
+        }
     }
 }
 
@@ -33,13 +86,13 @@ pub(crate) fn load_image(
     src: ImageSource<'_>,
     resize: Option<Dims>,
 ) -> Result<image::RgbaImage, Error> {
-    let img = match src {
-        ImageSource::Memory(data) => image::load_from_memory(data),
-        ImageSource::Path(path) => image::open(path),
-        ImageSource::Image(img) => Ok(img),
+    let img = match src.data_source {
+        DataSource::Memory(data) => image::load_from_memory(data),
+        DataSource::Path(path) => image::open(path),
+        DataSource::Image(img) => Ok(img),
     }?;
 
-    Ok(match resize {
+    let img = match resize {
         None => img.to_rgba(),
         Some(ref size) => {
             use image::GenericImageView;
@@ -55,7 +108,30 @@ pub(crate) fn load_image(
                 img.to_rgba()
             }
         }
-    })
+    };
+
+    let img = if let Some(mask) = src.mask {
+        apply_mask(&img, &mask)
+    } else {
+        img
+    };
+
+    Ok(img)
+}
+
+pub(crate) fn apply_mask(original_image: &image::RgbaImage, mask: &Mask) -> image::RgbaImage {
+    let mut image = original_image.clone();
+    let channel = mask.into();
+
+    for pixel_iter in image.enumerate_pixels_mut() {
+        let pixel = pixel_iter.2;
+        pixel[0] = pixel[channel];
+        pixel[1] = pixel[channel];
+        pixel[2] = pixel[channel];
+        pixel[3] = 255;
+    }
+
+    image
 }
 
 pub(crate) fn transform_to_guide_map(


### PR DESCRIPTION
Hey, found myself in a Hacktoberfest event this Saturday and it felt like a good opportunity to try my hand on #22 :).


Changes
----
To derive an inpaint mask from the alpha channel I felt it would be more "idiomatic" according to the lib to do some changes on `ImageSource`, therefore there are some minor modifications on it.

- Adds boolean `--inpaint-alpha` argument to CLI
- New `Mask` enum
- The original `ImageSource` is now `DataSource`
- `ImageSource` is now a struct with a `Mask` and a `DataSource`

##### Usage
```
texture-synthesis --out=result.png --inpaint-alpha generate silly_example_with_alpha.png
```


Example
----
Example:
![brick](https://user-images.githubusercontent.com/13659144/67248140-d8419280-f439-11e9-953a-20a9fdf0ead7.png)
Result:
![out](https://user-images.githubusercontent.com/13659144/67248141-d972bf80-f439-11e9-8902-398a7c042e65.png)

(Image source: https://unsplash.com)

Checklist
----
- [x] Run tests locally 
- [x] Run all examples locally
- [x] Run `rustfmt`
- [x] Run `clippy`