### PR TITLE
Replace failure with std::error::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [PR#57](https://github.com/EmbarkStudios/texture-synthesis/pull/57) CLI: Added the `flip-and-rotate` subcommand which applies flip and rotation transforms to each example input and adds them as additional examples. Thanks [@JD557](https://github.com/JD557)!
 
+### Changed
+- Replace [`failure`](https://crates.io/crates/failure) crate for error handling with just std::error::Error
+
 ### Fixed
 - Validate that the `--m-rand` / `random_sample_locations` parameter is > 0. [#45](https://github.com/EmbarkStudios/texture-synthesis/issues/45)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,11 +252,6 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "failure"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,11 +866,10 @@ dependencies = [
 
 [[package]]
 name = "texture-synthesis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "img_hash 2.1.0 (git+https://github.com/EmbarkStudios/img_hash.git?rev=c40da78)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,13 +880,13 @@ dependencies = [
 
 [[package]]
 name = "texture-synthesis-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "texture-synthesis 0.6.0",
+ "texture-synthesis 0.7.0",
 ]
 
 [[package]]
@@ -1025,7 +1019,6 @@ dependencies = [
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "texture-synthesis-cli"
 description = "A CLI for texture-synthesis"
 repository = "https://github.com/EmbarkStudios/texture-synthesis"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Anastasia Opara <anastasiaopara@gmail.com>",
@@ -30,7 +30,7 @@ atty = "0.2.13"
 indicatif = "0.12.0"
 minifb = { version = "0.13.0", optional = true }
 structopt = "0.3.0"
-texture-synthesis = { version = "0.6.0", path = "../lib" }
+texture-synthesis = { version = "0.7.0", path = "../lib" }
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "texture-synthesis"
 description = "Multiresolution Stochastic Texture Synthesis, a non-parametric example-based algorithm for image generation"
 repository = "https://github.com/EmbarkStudios/texture-synthesis"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Anastasia Opara <anastasiaopara@gmail.com>",
@@ -25,11 +25,6 @@ num_cpus = "1.10.1"
 rand = { version = "0.7.0", default-features = false } # avoid bringing in OS random gen that we don't use
 rand_pcg = "0.2.0"
 rstar = "0.5.0"
-
-[dependencies.failure]
-version = "0.1.5"
-default-features = false
-features = []
 
 [dependencies.image]
 version = "0.22.2"

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -18,8 +18,6 @@ impl fmt::Display for InvalidRange {
     }
 }
 
-// impl std::error::Error for InvalidRange {}
-
 #[derive(Debug)]
 pub struct SizeMismatch {
     pub(crate) input: (u32, u32),
@@ -56,6 +54,16 @@ pub enum Error {
     NoExamples,
     ///
     MapsCountMismatch(u32, u32),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Image(err) => Some(err),
+            Error::Io(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -95,9 +103,6 @@ impl fmt::Display for Error {
         }
     }
 }
-
-// TODO: Could also support backtraces and causes
-impl failure::Fail for Error {}
 
 impl From<image::ImageError> for Error {
     fn from(ie: image::ImageError) -> Self {


### PR DESCRIPTION

Is easier to just work with and use the standard error nowadays.

This changes the public interface so bumped the minor version to 0.7.0