### PR TITLE
Modify Threading Scheme to Improve Performance with Large Numbers of Threads

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -756,10 +756,12 @@ impl Generator {
 
             // Start with serial execution for the first few pixels, then go wide
             let n_workers = if redo_count < 1000 { 1 } else { max_workers };
-            if self.tree_grid.grid_width == 1 && n_workers > 1 {
+            if self.tree_grid.grid_width == 2 && n_workers > 1 {
                 let tile_adjusted_width = (self.output_size.width as f32 * 1.1) as u32 + 1;
                 let tile_adjusted_height = (self.output_size.height as f32 * 1.1) as u32 + 1;
-                let grid_cell_size = 100;
+                // heuristic: pick a cell size so that the expected number of completed points in any cell is k
+                let grid_cell_size = ((params.nearest_neighbors * self.output_size.height * self.output_size.height / redo_count as u32) as f64).sqrt() as u32 + 1;
+                println!("{} cell\n\n\n", grid_cell_size);
                 let new_tree_grid = TreeGrid::new(
                     tile_adjusted_width,
                     tile_adjusted_height,

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -1383,7 +1383,7 @@ impl STree {
         for place_to_look in places_to_look.iter() {
             if place_to_look.0 >= 0 && place_to_look.0 < self.size as i32 && place_to_look.1 >= 0 && place_to_look.1 < self.size as i32 {
                 let chunk_center_x = place_to_look.0 * self.chunk_size as i32 + (self.chunk_size / 2) as i32;
-                let chunk_center_y = place_to_look.0 * self.chunk_size as i32 + (self.chunk_size / 2) as i32;
+                let chunk_center_y = place_to_look.1 * self.chunk_size as i32 + (self.chunk_size / 2) as i32;
                 let is_center = place_to_look.2;
                 
                 if !is_center {

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -759,8 +759,9 @@ impl Generator {
                 has_fanned_out = true;
                 let tile_adjusted_width = (self.output_size.width as f32 * 1.1) as u32 + 1;
                 let tile_adjusted_height = (self.output_size.height as f32 * 1.1) as u32 + 1;
-                // heuristic: pick a cell size so that the expected number of resolved points in any cell is k
-                let grid_cell_size = ((params.nearest_neighbors * self.output_size.height * self.output_size.height / redo_count as u32) as f64).sqrt() as u32 + 1;
+                // heuristic: pick a cell size so that the expected number of resolved points in any cell is 4 * k
+                // this seems to be a safe overestimate
+                let grid_cell_size = ((params.nearest_neighbors * self.output_size.height * self.output_size.height / redo_count as u32) as f64).sqrt() as u32 * 2 + 1;
                 let new_tree_grid = TreeGrid::new(
                     tile_adjusted_width,
                     tile_adjusted_height,

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -1263,7 +1263,8 @@ impl STree {
         let chunk_y = (y / self.chunk_size) as i32;
         // Assume that all k nearest neighbors are in these cells
         // it looks like we are rarely wrong once enough pixels are filled in
-        let mut places_to_look = vec![
+        // the stucture of this tuple is (chunk_x, chunk_y, is_center_chunk, closest_x_point, closest_y_point)
+        let places_to_look = vec![
             (chunk_x, chunk_y, true, 0, 0),
             (chunk_x + 1, chunk_y, false, (chunk_x + 1) * self.chunk_size as i32, y as i32),
             (chunk_x - 1, chunk_y, false, chunk_x * self.chunk_size as i32, y as i32),
@@ -1281,7 +1282,7 @@ impl STree {
         result.reserve(k);
         
         // this isn't really the kth best distance but should be good enough for a simple time
-        let mut kth_best_distance = i32::max_value();
+        let mut kth_best_squared_distance = i32::max_value();
         //let mut num_skipped = 0;
         for place_to_look in places_to_look.iter() {
             if place_to_look.0 >= 0 && place_to_look.0 < self.size as i32 && place_to_look.1 >= 0 && place_to_look.1 < self.size as i32 {
@@ -1293,7 +1294,7 @@ impl STree {
                     let squared_distance_to_closest_possible_point_on_chunk = (x as i32 - place_to_look.3) * (x as i32 - place_to_look.3) + 
                         (y as i32 - place_to_look.4) * (y as i32 - place_to_look.4);
                         
-                    if squared_distance_to_closest_possible_point_on_chunk > kth_best_distance {
+                    if squared_distance_to_closest_possible_point_on_chunk > kth_best_squared_distance {
                         //num_skipped += 1;
                         continue;
                     }
@@ -1313,8 +1314,8 @@ impl STree {
                 // making this better could definitely make this whole step faster
                 if tmp_result.len() >= k {
                     let furthest_dist_for_chunk = tmp_result[tmp_result.len() - 1].2;
-                    if furthest_dist_for_chunk < kth_best_distance {
-                        kth_best_distance = furthest_dist_for_chunk;
+                    if furthest_dist_for_chunk < kth_best_squared_distance {
+                        kth_best_squared_distance = furthest_dist_for_chunk;
                     }
                 }
             }

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -709,8 +709,12 @@ impl Generator {
 
         {
             // now that we have all of the parameters we can setup our initial tree grid
-            let tile_adjusted_width = (self.output_size.width as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32 + 1;
-            let tile_adjusted_height = (self.output_size.height as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32 + 1;
+            let tile_adjusted_width =
+                (self.output_size.width as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32
+                    + 1;
+            let tile_adjusted_height =
+                (self.output_size.height as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32
+                    + 1;
             self.tree_grid = TreeGrid::new(
                 tile_adjusted_width,
                 tile_adjusted_height,
@@ -760,8 +764,14 @@ impl Generator {
             let n_workers = if redo_count < 1000 { 1 } else { max_workers };
             if !has_fanned_out && n_workers > 1 {
                 has_fanned_out = true;
-                let tile_adjusted_width = (self.output_size.width as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32 + 1;
-                let tile_adjusted_height = (self.output_size.height as f32 * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0)) as u32 + 1;
+                let tile_adjusted_width = (self.output_size.width as f32
+                    * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0))
+                    as u32
+                    + 1;
+                let tile_adjusted_height = (self.output_size.height as f32
+                    * (1.0 + TILING_BOUNDARY_PERCENTAGE * 2.0))
+                    as u32
+                    + 1;
                 // heuristic: pick a cell size so that the expected number of resolved points in any cell is 4 * k
                 // this seems to be a safe overestimate
                 let grid_cell_size =
@@ -1220,7 +1230,10 @@ impl TreeGrid {
         let mut rtrees: Vec<RwLock<RTree<[i32; 2]>>> = Vec::new();
         let grid_width = max((width + chunk_size - 1) / chunk_size, 1);
         let grid_height = max((height + chunk_size - 1) / chunk_size, 1);
-        println!("grid width {} width {} chunk_size {}", grid_width, width, chunk_size);
+        println!(
+            "grid width {} width {} chunk_size {}",
+            grid_width, width, chunk_size
+        );
         rtrees.resize_with((grid_width * grid_height) as usize, || {
             RwLock::new(RTree::new())
         });
@@ -1290,14 +1303,16 @@ impl TreeGrid {
                 x: chunk_x + 1,
                 y: chunk_y,
                 center: false,
-                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32 - self.offset_x) as i64,
+                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32
+                    - self.offset_x) as i64,
                 closest_point_on_boundary_y: y as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x - 1,
                 y: chunk_y,
                 center: false,
-                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x) as i64,
+                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x)
+                    as i64,
                 closest_point_on_boundary_y: y as i64,
             },
             ChunkSearchInfo {
@@ -1305,42 +1320,52 @@ impl TreeGrid {
                 y: chunk_y - 1,
                 center: false,
                 closest_point_on_boundary_x: x as i64,
-                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y)
+                    as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x,
                 y: chunk_y + 1,
                 center: false,
                 closest_point_on_boundary_x: x as i64,
-                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32
+                    - self.offset_y) as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x + 1,
                 y: chunk_y + 1,
                 center: false,
-                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32 - self.offset_x) as i64,
-                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32
+                    - self.offset_x) as i64,
+                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32
+                    - self.offset_y) as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x - 1,
                 y: chunk_y + 1,
                 center: false,
-                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x) as i64,
-                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x)
+                    as i64,
+                closest_point_on_boundary_y: ((chunk_y + 1) * self.chunk_size as i32
+                    - self.offset_y) as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x + 1,
                 y: chunk_y - 1,
                 center: false,
-                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32 - self.offset_x) as i64,
-                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_x: ((chunk_x + 1) * self.chunk_size as i32
+                    - self.offset_x) as i64,
+                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y)
+                    as i64,
             },
             ChunkSearchInfo {
                 x: chunk_x - 1,
                 y: chunk_y - 1,
                 center: false,
-                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x) as i64,
-                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y) as i64,
+                closest_point_on_boundary_x: (chunk_x * self.chunk_size as i32 - self.offset_x)
+                    as i64,
+                closest_point_on_boundary_y: (chunk_y * self.chunk_size as i32 - self.offset_y)
+                    as i64,
             },
         ];
         // Note locking all of them at different times seems to be the best way
@@ -1375,7 +1400,8 @@ impl TreeGrid {
                     }
                 }
 
-                let my_tree_index = self.get_tree_index(place_to_look.x as u32, place_to_look.y as u32);
+                let my_tree_index =
+                    self.get_tree_index(place_to_look.x as u32, place_to_look.y as u32);
                 let my_rtree = &self.rtrees[my_tree_index];
                 tmp_result.extend(
                     my_rtree

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -1230,10 +1230,6 @@ impl TreeGrid {
         let mut rtrees: Vec<RwLock<RTree<[i32; 2]>>> = Vec::new();
         let grid_width = max((width + chunk_size - 1) / chunk_size, 1);
         let grid_height = max((height + chunk_size - 1) / chunk_size, 1);
-        println!(
-            "grid width {} width {} chunk_size {}",
-            grid_width, width, chunk_size
-        );
         rtrees.resize_with((grid_width * grid_height) as usize, || {
             RwLock::new(RTree::new())
         });


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Disclaimer: This pr is a big proposed change and is not fully ready yet (inpaint and tiling are currently disabled but should be easily fixable). The code isn't the cleanest (feel free to let me know if it's too hard to read) and could be optimized further but I wanted to put it up as a proof of concept see what you think, make sure my big assumptions about how the code works were not very wrong, and see how this runs on other people's machines before I go further.

Motivation:
After seeing that @h3r2tic had virtually no improvements from my previous pr on their 32 core cpu I rented a larger cloud machine (64 logical cores, Intel Xeon) to test out how my previous changes behaved with many cores. It turns out I didn't see any improvement either. I then tried with lower numbers of threads (48, 32, 24, 16, 8, etc) and noticed that the run time actually seemed to improve as I decreased the number of threads (after some fiddling I found 22 threads was the best number for my instance) and barely went up until < 16 threads were in use. I figured this was a contention problem, so I added some additional logging to measure the time it took to acquire various locks and found (at least on that machine) the time it took to acquire a write lock on the rtree went up proportionally with the number of threads. Also as a side effect I believe it dwarfed any improvement from my previous change to the point where it was barely noticeable.

Proposed Improvements:
I've made several changes which I have seen reduce contention on my test machines.

1. Replace the RTree with a grid of Rtrees
Advantages:
Most of the time (at least in the later stages of synthesis) two threads may be working on totally different areas of the image and will not need to access the same sets of pixels and therefore should not have to wait to read / write. To address this after the first few stages of synthesis I replace the single rtree with a grid of rtrees. Writes only lock the rtree in the grid cell which the pixel is in and reads just read from a cell and its neighbors. Overall this has seemed to improve contention considerably in my tests. (Possibly a multi threaded rtree is better than this but I couldn't find one and it seemed more difficult / error prone to build for likely little upside)
Drawbacks:
The actual read itself is a little slower, this is balanced out by the fact that far more threads can read and write at the same time but it should be optimized a little more for machines with fewer cores
Technically we can miss some neighbors if a pixels k nearest neighbors are outside of the current cell + 8 adjacent cells, however because we only use a grid after the first few steps there should be enough pixels where this is never a problem. I have not seen quality degrade (see below)
Places for improvement:
The read can definitely be optimized more (especially important for cpus with small numbers of cores)
The number of grid cells is currently just a random constant but really should vary with the number of threads / size of the image / k

2. Don’t write to resolved queue until after stage is complete (don't updated it when a pixel is placed)
After I switched to the rtree grid I noticed that although writes were really fast the resolved queue seemed to be suddenly very hard to acquire a lock on. After looking at the code more I decided that each thread could have its own resolved queue and I could combine them at the end of the stage. I don't think this actually changes the behavior of the code because the only time we read from the resolved queue is to redo pixels done in the previous stages so we don't care what pixels other threads have updated in the current stage.
Advantages:
The resolved queue is no longer backed up leading to a speed up
Disadvantages:
None that I see

3. Remove the Update Queue entirely
I removed the update queue to simplify things a little because the writes were now fast enough where I could write every time instead of needing to batch.
Advantages:
Code is simpler, very small speed up
Disadvantages:
I can't think of too much but possibly this could be bad not to have in the first few stages before we switch to the grid of rtrees
Could also be worse for smaller grid sizes

Results:
I’ve tested on only two large machines so far:
Google Cloud N1:
Threads: 64
Cpu: Intel(R) Xeon(R) CPU @ 2.30GHz:
```
Command: time cargo run --release -- --threads 64 --out-size 2048 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~1m16s
AFTER: ~28.8s

Command: time cargo run --release -- --threads 32 --out-size 2048 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~1m12.8s
AFTER: ~35.7s

Command: time cargo run --release -- --threads 64 --out-size 1024 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~17.5s
AFTER: ~7.5s

Command time cargo run --release -- --threads 64 --out-size 512 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~4.1s
AFTER: ~1.9s
```

AWS Z1d:
Threads: 48
Cpu: Intel® Xeon® Scalable (Clock speed is a little unclear but Amazon claims up to 4ghz) 
```
Command: time cargo run --release -- --threads 48  --out-size 2048 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~41.5 seconds
AFTER: ~22.5 seconds

Command: time cargo run --release --  --threads 24  --out-size 2048 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~44.5 seconds
AFTER: ~29 seconds

Command: time cargo run --release --  --threads 48 --out-size 1024 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~9.7 seconds
AFTER: ~5.7 seconds 

time cargo run --release --  --threads 48 --out-size 512 --out out/01.jpg generate imgs/1.jpg
BEFORE: ~2.36 seconds
AFTER: ~1.47 seconds
```


I’m also curious to see what others get on cpus with large numbers of cores. @h3r2tic especially want to know how this runs on your 32 core cpu if you have the time.

Image Quality:
Because this change affects the threads and is fairly major I wanted to make sure that image quality did not change. It looks like tests still pass for everything that I didn’t break so the image hashes must be fairly close. I also manually inspected some large images but did not see any major changes. However it is important that the threads share one rtree for the first few stages before there are enough pixels to fill out a decent portion of the grid cells.

### Related Issues

I don’t believe this is related to any mentioned issue
