### PR TITLE
[ci] Switch to use cargo-deny GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,50 +58,35 @@ jobs:
           command: test
           args: --release
 
-  deny-check:
-    name: cargo-deny check
+  cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: download cargo-deny
-      shell: bash
-      env:
-        DVS: 0.3.0-beta
-        DREPO: EmbarkStudios/cargo-deny
-        TARGET: x86_64-unknown-linux-musl
-      run: |
-        temp_archive=$(mktemp --suffix=.tar.gz)
-        curl -L --output "$temp_archive" https://github.com/$DREPO/releases/download/$DVS/cargo-deny-$DVS-$TARGET.tar.gz
-
-        tar -xzvf "$temp_archive" -C . --strip-components=1 --wildcards "*/cargo-deny"
-    - name: cargo-deny check licenses
-      run: ./cargo-deny -L debug check license
-    - name: cargo-deny check bans
-      run: ./cargo-deny -L debug check ban
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@master # we use latest master as this is our own tool that we maintain
 
   publish-check:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: copy README
-      shell: bash
-      run: |
-        cp README.md lib
-        cp README.md cli
-    - name: cargo publish lib
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: --dry-run --allow-dirty --manifest-path lib/Cargo.toml
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: copy README
+        shell: bash
+        run: |
+          cp README.md lib
+          cp README.md cli
+      - name: cargo publish lib
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --dry-run --allow-dirty --manifest-path lib/Cargo.toml
 
   publish:
     name: Publish
@@ -109,38 +94,38 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: copy README
-      shell: bash
-      run: |
-        cp README.md lib
-        cp README.md cli
-    - name: cargo publish lib
-      uses: actions-rs/cargo@v1
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      with:
-        command: publish
-        args: --allow-dirty --manifest-path lib/Cargo.toml
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: cargo publish cli
-      uses: actions-rs/cargo@v1
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      with:
-        command: publish
-        args: --allow-dirty --manifest-path cli/Cargo.toml
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: copy README
+        shell: bash
+        run: |
+          cp README.md lib
+          cp README.md cli
+      - name: cargo publish lib
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        with:
+          command: publish
+          args: --allow-dirty --manifest-path lib/Cargo.toml
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo publish cli
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        with:
+          command: publish
+          args: --allow-dirty --manifest-path cli/Cargo.toml
 
   release:
     name: Release
@@ -233,6 +218,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: 'texture-synthesis*'
+          files: "texture-synthesis*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           command: test
           args: --release
 
-  cargo-deny:
+  deny-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: EmbarkStudios/cargo-deny-action@master # we use latest master as this is our own tool that we maintain
+      - uses: EmbarkStudios/cargo-deny-action@v0
 
   publish-check:
     name: Publish Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           args: --release
 
   deny-check:
+    name: cargo-deny
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This also upgrades from cargo-deny 0.3.0-beta to 0.4.2