### PR TITLE
Remove redundant calls to f64::exp, and avoid an allocation inside find_best_match

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -453,7 +453,11 @@ impl Generator {
         true
     }
 
-    fn get_gaussian_weighted_distances_to_k_neighs(&self, coord: Coord2D, k_neighs_2d: &[SignedCoord2D]) -> Vec<f64> {
+    fn get_gaussian_weighted_distances_to_k_neighs(
+        &self,
+        coord: Coord2D,
+        k_neighs_2d: &[SignedCoord2D],
+    ) -> Vec<f64> {
         let (dimx, dimy) = (
             f64::from(self.output_size.width),
             f64::from(self.output_size.height),
@@ -874,8 +878,11 @@ impl Generator {
                                 &mut k_neighs,
                             ) {
                                 //2.1 get distances to the pattern of neighbors
-                                let weighted_k_neighs_dist =
-                                    self.get_gaussian_weighted_distances_to_k_neighs(unresolved_2d, &k_neighs);
+                                let weighted_k_neighs_dist = self
+                                    .get_gaussian_weighted_distances_to_k_neighs(
+                                        unresolved_2d,
+                                        &k_neighs,
+                                    );
                                 let k_neighs_w_map_id =
                                     k_neighs.iter().map(|a| (*a, MapId(0))).collect::<Vec<_>>();
 


### PR DESCRIPTION

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

A micro-optimisation to reduce the number of calls to `f64::exp` and avoid an allocation in a fairly hot function. This gives a small speedup (see `cargo bench` output below), at the possible cost of making the code structure marginally worse (as the decision about how to decay scores with distances is no longer solely made within `find_best_match`). 

I have a few more "tidying" changes on a fork, and hope to also come up with a few more micro-optimisations. Shout if you'd rather not have such changes (e.g. because the minor improvements aren't worth the code churn, potential merge conflicts, or effort to review).

The first run below is on this branch; the second on master. Of the 35 results, 18 show an improvement after this change, 2 have regressed, and 15 are within noise threshold.

```
(21:47:37) ± [phil@phil-MS-7B85] ~/texture-synthesis (exp U:1 ?:1 ✗) 
→ cargo bench
  Downloaded itertools v0.8.2
 ...
   Compiling texture-synthesis v0.7.1 (/home/phil/texture-synthesis/lib)
    Finished bench [optimized + debuginfo] target(s) in 22.66s
     Running target/release/deps/all_the_things-ae87f5b0bcc72ba6
single_example/25       time:   [17.767 ms 17.807 ms 17.865 ms]                             
single_example/50       time:   [61.838 ms 62.070 ms 62.299 ms]                             
Benchmarking single_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.8s or reduce sample count to 10
single_example/100      time:   [76.087 ms 76.385 ms 76.679 ms]                             
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking single_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 14.8s or reduce sample count to 10
single_example/200      time:   [238.63 ms 239.47 ms 240.02 ms]                             
Benchmarking single_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 61.0s or reduce sample count to 10
single_example/400      time:   [1.0745 s 1.1163 s 1.1380 s]                                

multi_example/25        time:   [28.842 ms 28.937 ms 29.029 ms]                            
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
multi_example/50        time:   [65.153 ms 65.654 ms 66.266 ms]                            
Benchmarking multi_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.5s or reduce sample count to 10
multi_example/100       time:   [107.40 ms 108.02 ms 108.86 ms]                            
Benchmarking multi_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 19.7s or reduce sample count to 10
multi_example/200       time:   [292.30 ms 309.84 ms 322.17 ms]                            
Benchmarking multi_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 77.4s or reduce sample count to 10
multi_example/400       time:   [1.1518 s 1.1777 s 1.2046 s]                               

Benchmarking guided/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.0s or reduce sample count to 10
guided/25               time:   [43.079 ms 43.185 ms 43.354 ms]                    
Benchmarking guided/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 11.1s or reduce sample count to 10
guided/50               time:   [95.197 ms 95.457 ms 95.920 ms]                    
Benchmarking guided/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 13.9s or reduce sample count to 10
guided/100              time:   [146.16 ms 147.61 ms 149.38 ms]                     
Benchmarking guided/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 29.2s or reduce sample count to 10
guided/200              time:   [371.66 ms 378.57 ms 390.03 ms]                     
Benchmarking guided/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 92.6s or reduce sample count to 10
guided/400              time:   [1.4656 s 1.4811 s 1.4987 s]                        

Benchmarking style_transfer/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or reduce sample count to 10
style_transfer/25       time:   [39.681 ms 39.977 ms 40.212 ms]                            
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking style_transfer/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 12.3s or reduce sample count to 10
style_transfer/50       time:   [104.54 ms 105.51 ms 106.21 ms]                            
Benchmarking style_transfer/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.6s or reduce sample count to 10
style_transfer/100      time:   [160.77 ms 162.52 ms 163.72 ms]                             
Benchmarking style_transfer/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 30.0s or reduce sample count to 10
style_transfer/200      time:   [402.65 ms 418.76 ms 427.76 ms]                             
Benchmarking style_transfer/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 112.0s or reduce sample count to 10
style_transfer/400      time:   [1.6054 s 1.6527 s 1.7268 s]                                

inpaint/25              time:   [9.4975 ms 9.5271 ms 9.5721 ms]                      
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
inpaint/50              time:   [65.660 ms 65.814 ms 66.003 ms]                      
Benchmarking inpaint/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.4s or reduce sample count to 10
inpaint/100             time:   [74.601 ms 74.772 ms 75.012 ms]                      
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking inpaint/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.6s or reduce sample count to 10
inpaint/200             time:   [122.08 ms 123.43 ms 125.87 ms]                      
Benchmarking inpaint/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 28.6s or reduce sample count to 10
inpaint/400             time:   [365.76 ms 372.90 ms 377.83 ms]                      

inpaint_channel/25      time:   [4.7145 ms 4.7403 ms 4.7712 ms]                              
inpaint_channel/50      time:   [31.352 ms 31.374 ms 31.389 ms]                              
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  2 (20.00%) high mild
Benchmarking inpaint_channel/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.0s or reduce sample count to 10
inpaint_channel/100     time:   [112.51 ms 113.58 ms 114.18 ms]                              
Benchmarking inpaint_channel/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.3s or reduce sample count to 10
inpaint_channel/200     time:   [269.03 ms 271.96 ms 276.32 ms]                              
Benchmarking inpaint_channel/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 25.7s or reduce sample count to 10
inpaint_channel/400     time:   [299.13 ms 304.01 ms 307.96 ms]                              

tiling/25               time:   [18.996 ms 19.019 ms 19.039 ms]                     
tiling/50               time:   [68.383 ms 68.633 ms 68.779 ms]                     
Benchmarking tiling/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.9s or reduce sample count to 10
tiling/100              time:   [110.90 ms 111.57 ms 112.36 ms]                     
Benchmarking tiling/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.1s or reduce sample count to 10
tiling/200              time:   [251.37 ms 254.81 ms 256.92 ms]                     
Benchmarking tiling/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 54.4s or reduce sample count to 10
tiling/400              time:   [860.05 ms 884.77 ms 907.61 ms]                     

(22:03:24) ± [phil@phil-MS-7B85] ~/texture-synthesis (exp U:1 ?:1 ✗) 
→ git checkout master
M	Cargo.toml
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
(22:03:32) ± [phil@phil-MS-7B85] ~/texture-synthesis (master U:1 ?:1 ✗) 
→ cargo bench
   Compiling texture-synthesis v0.7.1 (/home/phil/texture-synthesis/lib)
    Finished bench [optimized + debuginfo] target(s) in 3.18s
     Running target/release/deps/all_the_things-ae87f5b0bcc72ba6
single_example/25       time:   [18.688 ms 18.717 ms 18.749 ms]                             
                        change: [+4.4714% +4.7991% +5.0909%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high mild
Benchmarking single_example/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.1s or reduce sample count to 10
single_example/50       time:   [63.394 ms 63.645 ms 63.878 ms]                            
                        change: [+1.6561% +2.2907% +2.9049%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking single_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.2s or reduce sample count to 10
single_example/100      time:   [81.059 ms 81.603 ms 82.119 ms]                             
                        change: [+5.6537% +6.4393% +7.1684%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking single_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.0s or reduce sample count to 10
single_example/200      time:   [260.94 ms 263.09 ms 266.11 ms]                             
                        change: [+7.1714% +9.2788% +11.169%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking single_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 65.9s or reduce sample count to 10
single_example/400      time:   [1.1922 s 1.2144 s 1.2329 s]                                
                        change: [+7.8154% +10.331% +12.903%] (p = 0.00 < 0.05)
                        Performance has regressed.

multi_example/25        time:   [29.407 ms 29.492 ms 29.600 ms]                            
                        change: [+1.4117% +1.8724% +2.2900%] (p = 0.00 < 0.05)
                        Performance has regressed.
multi_example/50        time:   [66.174 ms 66.505 ms 66.979 ms]                            
                        change: [+0.2930% +1.0543% +1.8674%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Benchmarking multi_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.7s or reduce sample count to 10
multi_example/100       time:   [112.95 ms 115.00 ms 117.27 ms]                            
                        change: [+3.4374% +4.8929% +6.4752%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking multi_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 21.6s or reduce sample count to 10
multi_example/200       time:   [314.33 ms 320.11 ms 324.60 ms]                            
                        change: [+3.0717% +6.9506% +10.533%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking multi_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 81.3s or reduce sample count to 10
multi_example/400       time:   [1.1232 s 1.1745 s 1.2397 s]                               
                        change: [-3.1090% +0.3789% +4.4493%] (p = 0.85 > 0.05)
                        No change in performance detected.

Benchmarking guided/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s or reduce sample count to 10
guided/25               time:   [44.775 ms 44.908 ms 45.016 ms]                    
                        change: [+3.2030% +3.6842% +4.1614%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking guided/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 11.3s or reduce sample count to 10
guided/50               time:   [97.833 ms 98.217 ms 98.597 ms]                    
                        change: [+1.5603% +2.3222% +3.0735%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking guided/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 14.2s or reduce sample count to 10
guided/100              time:   [147.88 ms 148.33 ms 148.74 ms]                     
                        change: [-0.5589% +0.5641% +1.7350%] (p = 0.38 > 0.05)
                        No change in performance detected.
Benchmarking guided/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 26.6s or reduce sample count to 10
guided/200              time:   [360.30 ms 361.36 ms 362.85 ms]                     
                        change: [-9.8066% -6.9389% -4.1014%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking guided/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 88.2s or reduce sample count to 10
guided/400              time:   [1.4420 s 1.4450 s 1.4478 s]                        
                        change: [-4.6879% -3.2212% -1.8935%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking style_transfer/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or reduce sample count to 10
style_transfer/25       time:   [41.283 ms 41.374 ms 41.504 ms]                            
                        change: [+2.2513% +3.3136% +4.2610%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking style_transfer/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 12.6s or reduce sample count to 10
style_transfer/50       time:   [110.71 ms 111.87 ms 112.89 ms]                            
                        change: [+4.2808% +5.4715% +6.9512%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking style_transfer/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.3s or reduce sample count to 10
style_transfer/100      time:   [171.66 ms 173.55 ms 177.33 ms]                             
                        change: [+6.1529% +8.2286% +10.201%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking style_transfer/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 30.3s or reduce sample count to 10
style_transfer/200      time:   [410.24 ms 416.13 ms 421.42 ms]                             
                        change: [-1.9643% +0.6980% +3.4890%] (p = 0.63 > 0.05)
                        No change in performance detected.
Benchmarking style_transfer/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 104.9s or reduce sample count to 10
style_transfer/400      time:   [1.6660 s 1.6928 s 1.7408 s]                                
                        change: [-2.7622% +0.8895% +4.8245%] (p = 0.66 > 0.05)
                        No change in performance detected.

inpaint/25              time:   [9.3783 ms 9.4596 ms 9.5666 ms]                      
                        change: [-1.3271% -0.4527% +0.5602%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
inpaint/50              time:   [66.021 ms 66.798 ms 67.523 ms]                      
                        change: [+0.1818% +0.8015% +1.5796%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking inpaint/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s or reduce sample count to 10
inpaint/100             time:   [76.075 ms 76.500 ms 76.848 ms]                      
                        change: [+0.4756% +1.5808% +2.5230%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking inpaint/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.9s or reduce sample count to 10
inpaint/200             time:   [120.99 ms 123.90 ms 126.33 ms]                      
                        change: [-2.4368% -0.2250% +2.0818%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low severe
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking inpaint/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 28.8s or reduce sample count to 10
inpaint/400             time:   [383.95 ms 394.39 ms 405.32 ms]                      
                        change: [+1.8916% +5.2041% +8.4299%] (p = 0.01 < 0.05)
                        Performance has regressed.

inpaint_channel/25      time:   [4.8921 ms 4.9211 ms 4.9445 ms]                              
                        change: [+1.9979% +2.8728% +3.7636%] (p = 0.00 < 0.05)
                        Performance has regressed.
inpaint_channel/50      time:   [31.990 ms 32.058 ms 32.140 ms]                              
                        change: [+1.8435% +2.0467% +2.2582%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking inpaint_channel/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or reduce sample count to 10
inpaint_channel/100     time:   [114.85 ms 115.37 ms 115.92 ms]                              
                        change: [+1.3071% +2.0387% +2.7809%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking inpaint_channel/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.7s or reduce sample count to 10
inpaint_channel/200     time:   [273.31 ms 274.36 ms 275.84 ms]                              
                        change: [-0.5829% +0.6300% +2.0340%] (p = 0.38 > 0.05)
                        No change in performance detected.
Benchmarking inpaint_channel/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 26.0s or reduce sample count to 10
inpaint_channel/400     time:   [306.92 ms 310.73 ms 313.30 ms]                              
                        change: [-0.8670% +0.9220% +2.6970%] (p = 0.33 > 0.05)
                        No change in performance detected.

tiling/25               time:   [19.292 ms 19.306 ms 19.329 ms]                     
                        change: [+1.2783% +1.5100% +1.7512%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
tiling/50               time:   [69.220 ms 69.451 ms 69.635 ms]                     
                        change: [+0.9672% +1.4792% +2.0185%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking tiling/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.9s or reduce sample count to 10
tiling/100              time:   [110.93 ms 111.38 ms 112.16 ms]                     
                        change: [-0.4865% +0.0730% +0.6564%] (p = 0.82 > 0.05)
                        No change in performance detected.
Benchmarking tiling/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.6s or reduce sample count to 10
tiling/200              time:   [251.73 ms 252.42 ms 253.06 ms]                     
                        change: [-1.9565% -0.9088% +0.2050%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking tiling/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 53.0s or reduce sample count to 10
tiling/400              time:   [849.62 ms 865.06 ms 882.51 ms]                     
                        change: [-4.2750% -1.9776% +0.3547%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```