### PR TITLE
Don't clear k_neighs in CandidateStructs as they get overwritten before use

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -38,12 +38,6 @@ struct CandidateStruct {
     id: (PatchId, MapId),
 }
 
-impl CandidateStruct {
-    fn clear(&mut self) {
-        self.k_neighs.clear();
-    }
-}
-
 struct GuidesStruct<'a> {
     pub example_guides: Vec<ImageBuffer<'a>>, // as many as there are examples
     pub target_guide: ImageBuffer<'a>,        //single for final color_map
@@ -853,9 +847,6 @@ impl Generator {
                             let unresolved_2d = next_unresolved.to_2d(self.output_size);
 
                             // Clear previously found candidate neighbors
-                            for cand in candidates.iter_mut() {
-                                cand.clear();
-                            }
                             k_neighs.clear();
 
                             // 2. find K nearest resolved neighs


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
Remove calls to `CandidateStruct::clear` (and the function itself).

These are not necessary as:
* Only `find_candidates` directly uses the `Vec` whose elements are being cleared - everything else uses the truncated slice returned by `find_candidates`.
* All `CandidateStructs` in that slice have been updated in the `if check_coord_validity` block within `find_candidates`, and this resizes the `CandidateStruct`'s `k_neighs` to have length matching the input `k_neighs` and then overwrites all of its values.

Clearing these vectors meant that `find_candidates` was wasting time writing values into the underlying allocations, only to immediately (potentially truncate the vecs and then) overwrite the values without using them. The `cargo bench` logs below show an improvement on every benchmark, ranging from 2.7% to 9.3%.

This might make the code slightly more brittle in the face of future changes, but 1. the regression tests should catch this, and 2. I don't think this is any more subtle than the existing implicit invariants between functions.

(This has trivial merge conflicts with https://github.com/EmbarkStudios/texture-synthesis/pull/82, but I'll fix those after you've decided which PRs you want to merge.)

```
(00:27:14) ± [phil@phil-MS-7B85] ~/texture-synthesis (master U:1 ✗) 
→ cargo bench
    Finished bench [optimized + debuginfo] target(s) in 0.02s
     Running target/release/deps/all_the_things-ae87f5b0bcc72ba6
single_example/25       time:   [18.693 ms 18.804 ms 18.858 ms]                             
Benchmarking single_example/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.1s or reduce sample count to 10
single_example/50       time:   [63.274 ms 63.614 ms 64.178 ms]                            
Benchmarking single_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.1s or reduce sample count to 10
single_example/100      time:   [80.489 ms 81.139 ms 81.616 ms]                             
Benchmarking single_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.7s or reduce sample count to 10
single_example/200      time:   [253.30 ms 257.90 ms 262.83 ms]                             
Benchmarking single_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 68.5s or reduce sample count to 10
single_example/400      time:   [1.1349 s 1.1459 s 1.1564 s]                                
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

multi_example/25        time:   [29.497 ms 29.542 ms 29.598 ms]                            
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
multi_example/50        time:   [66.781 ms 66.954 ms 67.176 ms]                            
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking multi_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.6s or reduce sample count to 10
multi_example/100       time:   [110.40 ms 112.87 ms 114.24 ms]                            
Benchmarking multi_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 20.9s or reduce sample count to 10
multi_example/200       time:   [288.69 ms 292.45 ms 295.18 ms]                            
Benchmarking multi_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 74.1s or reduce sample count to 10
multi_example/400       time:   [1.1246 s 1.1293 s 1.1335 s]                               
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

Benchmarking guided/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.3s or reduce sample count to 10
guided/25               time:   [44.807 ms 44.966 ms 45.075 ms]                    
Benchmarking guided/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 11.2s or reduce sample count to 10
guided/50               time:   [97.761 ms 98.027 ms 98.415 ms]                    
Benchmarking guided/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 14.1s or reduce sample count to 10
guided/100              time:   [147.59 ms 148.26 ms 148.74 ms]                     
Benchmarking guided/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 26.8s or reduce sample count to 10
guided/200              time:   [362.14 ms 363.35 ms 364.77 ms]                     
Benchmarking guided/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 88.6s or reduce sample count to 10
guided/400              time:   [1.4465 s 1.4546 s 1.4724 s]                        
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Benchmarking style_transfer/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or reduce sample count to 10
style_transfer/25       time:   [40.782 ms 40.850 ms 40.890 ms]                            
Benchmarking style_transfer/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 12.4s or reduce sample count to 10
style_transfer/50       time:   [107.48 ms 108.21 ms 109.03 ms]                            
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking style_transfer/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.8s or reduce sample count to 10
style_transfer/100      time:   [166.48 ms 167.39 ms 167.93 ms]                             
Benchmarking style_transfer/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 29.9s or reduce sample count to 10
style_transfer/200      time:   [403.18 ms 403.64 ms 404.13 ms]                             
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking style_transfer/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 99.7s or reduce sample count to 10
style_transfer/400      time:   [1.6331 s 1.6627 s 1.7044 s]                                
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

inpaint/25              time:   [9.7144 ms 9.7284 ms 9.7552 ms]                      
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
inpaint/50              time:   [66.538 ms 66.695 ms 66.959 ms]                      
Benchmarking inpaint/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.5s or reduce sample count to 10
inpaint/100             time:   [74.472 ms 74.646 ms 74.929 ms]                      
Benchmarking inpaint/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.5s or reduce sample count to 10
inpaint/200             time:   [120.23 ms 120.56 ms 121.06 ms]                      
Benchmarking inpaint/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 27.9s or reduce sample count to 10
inpaint/400             time:   [365.87 ms 373.55 ms 379.22 ms]                      
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  2 (20.00%) high severe

inpaint_channel/25      time:   [4.9372 ms 4.9688 ms 4.9951 ms]                              
inpaint_channel/50      time:   [31.766 ms 31.809 ms 31.850 ms]                              
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking inpaint_channel/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.3s or reduce sample count to 10
inpaint_channel/100     time:   [115.57 ms 116.02 ms 116.51 ms]                              
Benchmarking inpaint_channel/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.8s or reduce sample count to 10
inpaint_channel/200     time:   [273.50 ms 274.48 ms 275.28 ms]                              
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking inpaint_channel/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 26.1s or reduce sample count to 10
inpaint_channel/400     time:   [303.03 ms 304.90 ms 307.59 ms]                              

tiling/25               time:   [19.193 ms 19.281 ms 19.330 ms]                     
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
tiling/50               time:   [69.064 ms 69.300 ms 69.561 ms]                     
Benchmarking tiling/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.0s or reduce sample count to 10
tiling/100              time:   [111.89 ms 112.26 ms 112.58 ms]                     
Benchmarking tiling/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.9s or reduce sample count to 10
tiling/200              time:   [251.06 ms 252.66 ms 255.24 ms]                     
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking tiling/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 55.3s or reduce sample count to 10
tiling/400              time:   [844.27 ms 856.40 ms 879.73 ms]                     

(00:42:24) ± [phil@phil-MS-7B85] ~/texture-synthesis (master U:1 ✗) 
→ git checkout clear
M	Cargo.toml
Switched to branch 'clear'
(00:42:33) ± [phil@phil-MS-7B85] ~/texture-synthesis (clear U:1 ✗) 
→ cargo bench
   Compiling texture-synthesis v0.7.1 (/home/phil/texture-synthesis/lib)
    Finished bench [optimized + debuginfo] target(s) in 3.21s
     Running target/release/deps/all_the_things-ae87f5b0bcc72ba6
single_example/25       time:   [17.028 ms 17.083 ms 17.147 ms]                             
                        change: [-9.3672% -8.7533% -8.1686%] (p = 0.00 < 0.05)
                        Performance has improved.
single_example/50       time:   [59.743 ms 60.357 ms 61.126 ms]                             
                        change: [-7.3167% -6.1487% -4.8491%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking single_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s or reduce sample count to 10
single_example/100      time:   [73.946 ms 74.424 ms 74.935 ms]                             
                        change: [-8.8051% -7.9597% -6.9518%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking single_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.0s or reduce sample count to 10
single_example/200      time:   [242.18 ms 249.56 ms 253.56 ms]                             
                        change: [-8.9597% -6.3845% -3.5055%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking single_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 63.9s or reduce sample count to 10
single_example/400      time:   [1.0622 s 1.0720 s 1.0829 s]                                
                        change: [-8.4440% -6.7074% -5.1487%] (p = 0.00 < 0.05)
                        Performance has improved.

multi_example/25        time:   [27.885 ms 27.950 ms 28.006 ms]                            
                        change: [-5.8850% -5.5803% -5.3017%] (p = 0.00 < 0.05)
                        Performance has improved.
multi_example/50        time:   [62.411 ms 62.491 ms 62.586 ms]                            
                        change: [-7.4824% -7.0549% -6.6954%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking multi_example/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.3s or reduce sample count to 10
multi_example/100       time:   [103.27 ms 103.68 ms 104.17 ms]                            
                        change: [-7.7070% -6.3514% -4.9766%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking multi_example/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.7s or reduce sample count to 10
multi_example/200       time:   [274.45 ms 276.68 ms 279.67 ms]                            
                        change: [-6.5710% -5.1934% -3.8146%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking multi_example/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 70.3s or reduce sample count to 10
multi_example/400       time:   [1.0503 s 1.0565 s 1.0624 s]                               
                        change: [-6.9426% -6.2031% -5.4608%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking guided/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s or reduce sample count to 10
guided/25               time:   [42.305 ms 42.419 ms 42.485 ms]                    
                        change: [-5.9008% -5.3992% -4.8787%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking guided/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 10.8s or reduce sample count to 10
guided/50               time:   [93.316 ms 93.543 ms 93.963 ms]                    
                        change: [-4.5793% -3.7863% -2.8014%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking guided/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 13.9s or reduce sample count to 10
guided/100              time:   [142.08 ms 142.85 ms 143.77 ms]                     
                        change: [-3.8309% -3.2368% -2.6165%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking guided/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 25.6s or reduce sample count to 10
guided/200              time:   [350.42 ms 352.93 ms 354.70 ms]                     
                        change: [-3.4985% -2.9552% -2.3908%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking guided/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 85.0s or reduce sample count to 10
guided/400              time:   [1.4172 s 1.4214 s 1.4280 s]                        
                        change: [-3.8340% -2.7305% -1.8037%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high severe

Benchmarking style_transfer/25: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or reduce sample count to 10
style_transfer/25       time:   [39.400 ms 39.478 ms 39.608 ms]                            
                        change: [-3.3540% -3.1010% -2.8249%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking style_transfer/50: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 12.1s or reduce sample count to 10
style_transfer/50       time:   [104.56 ms 105.57 ms 106.11 ms]                            
                        change: [-3.6860% -2.9727% -2.2476%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking style_transfer/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.5s or reduce sample count to 10
style_transfer/100      time:   [159.56 ms 160.31 ms 161.30 ms]                             
                        change: [-5.0867% -4.1674% -3.2107%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking style_transfer/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 29.1s or reduce sample count to 10
style_transfer/200      time:   [393.59 ms 396.47 ms 399.19 ms]                             
                        change: [-2.6654% -1.7273% -0.8200%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking style_transfer/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 96.3s or reduce sample count to 10
style_transfer/400      time:   [1.5707 s 1.5929 s 1.6200 s]                                
                        change: [-6.1744% -4.5163% -2.9560%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

inpaint/25              time:   [9.0026 ms 9.0764 ms 9.1786 ms]                      
                        change: [-7.1868% -6.4780% -5.8273%] (p = 0.00 < 0.05)
                        Performance has improved.
inpaint/50              time:   [62.473 ms 62.601 ms 62.768 ms]                      
                        change: [-6.7634% -6.3058% -5.8717%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking inpaint/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s or reduce sample count to 10
inpaint/100             time:   [71.506 ms 71.640 ms 71.870 ms]                      
                        change: [-4.5840% -4.1028% -3.5949%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking inpaint/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or reduce sample count to 10
inpaint/200             time:   [113.60 ms 114.39 ms 115.01 ms]                      
                        change: [-6.1762% -5.4801% -4.7702%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking inpaint/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 27.1s or reduce sample count to 10
inpaint/400             time:   [348.91 ms 349.81 ms 351.03 ms]                      
                        change: [-5.9153% -4.5681% -3.3267%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

inpaint_channel/25      time:   [4.4906 ms 4.5170 ms 4.5322 ms]                              
                        change: [-9.9746% -9.2573% -8.5351%] (p = 0.00 < 0.05)
                        Performance has improved.
inpaint_channel/50      time:   [29.718 ms 29.780 ms 29.866 ms]                              
                        change: [-7.2329% -6.5289% -5.9316%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking inpaint_channel/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.7s or reduce sample count to 10
inpaint_channel/100     time:   [106.75 ms 107.23 ms 107.99 ms]                              
                        change: [-7.9891% -7.4268% -6.8270%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking inpaint_channel/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.8s or reduce sample count to 10
inpaint_channel/200     time:   [257.89 ms 259.07 ms 260.86 ms]                              
                        change: [-6.8981% -6.1259% -5.3470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking inpaint_channel/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 24.9s or reduce sample count to 10
inpaint_channel/400     time:   [286.58 ms 287.77 ms 290.07 ms]                              
                        change: [-6.3946% -5.3762% -4.3845%] (p = 0.00 < 0.05)
                        Performance has improved.

tiling/25               time:   [17.986 ms 18.079 ms 18.156 ms]                     
                        change: [-6.5634% -5.9376% -5.2806%] (p = 0.00 < 0.05)
                        Performance has improved.
tiling/50               time:   [64.703 ms 64.819 ms 64.879 ms]                     
                        change: [-6.8273% -6.4673% -6.0865%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking tiling/100: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.6s or reduce sample count to 10
tiling/100              time:   [104.27 ms 104.85 ms 105.48 ms]                     
                        change: [-6.8928% -6.3589% -5.8039%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking tiling/200: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.1s or reduce sample count to 10
tiling/200              time:   [239.22 ms 240.63 ms 242.54 ms]                     
                        change: [-6.2915% -5.5421% -4.8063%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking tiling/400: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 51.7s or reduce sample count to 10
tiling/400              time:   [816.56 ms 820.19 ms 825.45 ms]                     
                        change: [-8.6190% -6.3146% -3.9949%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```
