### PR TITLE
Add WASM/WASI support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,26 @@ jobs:
           command: test
           args: --release --all-features
 
+  build:
+    name: Build WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-wasi
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --target wasm32-wasi
+
   deny-check:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,10 @@ path = "src/main.rs"
 bench = false
 
 [dependencies]
+structopt = "0.3.7"
+texture-synthesis = { version = "0.7.1", path = "../lib" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # We unfortunately can't use clicolors-control which is used by indicatif
 # because it only ever operates on stdout, even though we only ever print
 # to stderr. This is also why indicatif colors don't work if you pipe
@@ -29,8 +33,6 @@ bench = false
 atty = "0.2.13"
 indicatif = "0.13.0"
 minifb = { version = "0.15.1", optional = true }
-structopt = "0.3.7"
-texture-synthesis = { version = "0.7.1", path = "../lib" }
 
 [features]
 default = []

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,9 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
+#[cfg(not(target_arch = "wasm32"))]
+mod progress_window;
+
 use structopt::StructOpt;
 
 use std::path::PathBuf;
@@ -135,6 +138,7 @@ struct Tweaks {
     show_window: bool,
     /// Show a window with the current progress of the generation
     #[structopt(long)]
+    #[cfg(not(target_arch = "wasm32"))]
     no_progress: bool,
     /// A seed value for the random generator to give pseudo-deterministic result.
     /// Smaller details will be different from generation to generation due to the
@@ -220,12 +224,7 @@ struct Opt {
 
 fn main() {
     if let Err(e) = real_main() {
-        if atty::is(atty::Stream::Stderr) {
-            eprintln!("\x1b[31merror\x1b[0m: {}", e);
-        } else {
-            eprintln!("error: {}", e);
-        }
-
+        eprintln!("error: {}", e);
         std::process::exit(1);
     }
 }
@@ -354,9 +353,10 @@ fn real_main() -> Result<(), Error> {
 
     let session = sb.build()?;
 
+    #[cfg(not(target_arch = "wasm32"))]
     let progress: Option<Box<dyn texture_synthesis::GeneratorProgress>> =
         if !args.tweaks.no_progress {
-            let progress = ProgressWindow::new();
+            let progress = progress_window::ProgressWindow::new();
 
             #[cfg(feature = "progress")]
             let progress = {
@@ -371,6 +371,9 @@ fn real_main() -> Result<(), Error> {
         } else {
             None
         };
+
+    #[cfg(target_arch = "wasm32")]
+    let progress = None;
 
     let generated = session.run(progress);
 
@@ -387,135 +390,4 @@ fn real_main() -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-#[cfg(feature = "progress")]
-use minifb::Window;
-
-pub struct ProgressWindow {
-    #[cfg(feature = "progress")]
-    window: Option<(Window, std::time::Duration, std::time::Instant)>,
-
-    total_pb: ProgressBar,
-    stage_pb: ProgressBar,
-
-    total_len: usize,
-    stage_len: usize,
-    stage_num: u32,
-}
-
-impl ProgressWindow {
-    fn new() -> Self {
-        let multi_pb = MultiProgress::new();
-        let sty = ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] {bar:40.cyan/blue} {percent}%")
-            .progress_chars("##-");
-
-        let total_pb = multi_pb.add(ProgressBar::new(100));
-        total_pb.set_style(sty);
-
-        let sty = ProgressStyle::default_bar()
-            .template(" stage {msg:>3} {bar:40.cyan/blue} {percent}%")
-            .progress_chars("##-");
-        let stage_pb = multi_pb.add(ProgressBar::new(100));
-        stage_pb.set_style(sty);
-
-        std::thread::spawn(move || {
-            let _ = multi_pb.join();
-        });
-
-        Self {
-            #[cfg(feature = "progress")]
-            window: None,
-            total_pb,
-            stage_pb,
-            total_len: 100,
-            stage_len: 100,
-            stage_num: 0,
-        }
-    }
-
-    #[cfg(feature = "progress")]
-    fn with_preview(
-        mut self,
-        size: Dims,
-        update_every: std::time::Duration,
-    ) -> Result<Self, Error> {
-        let window = Window::new(
-            "Texture Synthesis",
-            size.width as usize,
-            size.height as usize,
-            minifb::WindowOptions::default(),
-        )
-        .unwrap();
-
-        self.window = Some((window, update_every, std::time::Instant::now()));
-
-        Ok(self)
-    }
-}
-
-impl Drop for ProgressWindow {
-    fn drop(&mut self) {
-        self.total_pb.finish();
-        self.stage_pb.finish();
-    }
-}
-
-impl texture_synthesis::GeneratorProgress for ProgressWindow {
-    fn update(&mut self, update: texture_synthesis::ProgressUpdate<'_>) {
-        if update.total.total != self.total_len {
-            self.total_len = update.total.total;
-            self.total_pb.set_length(self.total_len as u64);
-        }
-
-        if update.stage.total != self.stage_len {
-            self.stage_len = update.stage.total;
-            self.stage_pb.set_length(self.stage_len as u64);
-            self.stage_num += 1;
-            self.stage_pb.set_message(&self.stage_num.to_string());
-        }
-
-        self.total_pb.set_position(update.total.current as u64);
-        self.stage_pb.set_position(update.stage.current as u64);
-
-        #[cfg(feature = "progress")]
-        {
-            if let Some((ref mut window, ref dur, ref mut last_update)) = self.window {
-                let now = std::time::Instant::now();
-
-                if now - *last_update < *dur {
-                    return;
-                }
-
-                *last_update = now;
-
-                if !window.is_open() {
-                    return;
-                }
-
-                let pixels = &update.image;
-                if pixels.len() % 4 != 0 {
-                    return;
-                }
-
-                // The pixel channels are in a different order so the colors are
-                // incorrect in the window, but at least the shape and unfilled pixels
-                // are still apparent
-                let pixels: &[u32] = unsafe {
-                    let raw_pixels: &[u8] = pixels;
-                    #[allow(clippy::cast_ptr_alignment)]
-                    std::mem::transmute(&*(raw_pixels as *const [u8] as *const [u32]))
-                };
-
-                // We don't particularly care if this fails
-                let _ = window.update_with_buffer(
-                    pixels,
-                    update.image.width() as usize,
-                    update.image.height() as usize,
-                );
-            }
-        }
-    }
 }

--- a/cli/src/progress_window.rs
+++ b/cli/src/progress_window.rs
@@ -1,0 +1,130 @@
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+#[cfg(feature = "progress")]
+use minifb::Window;
+
+pub struct ProgressWindow {
+    #[cfg(feature = "progress")]
+    window: Option<(Window, std::time::Duration, std::time::Instant)>,
+
+    total_pb: ProgressBar,
+    stage_pb: ProgressBar,
+
+    total_len: usize,
+    stage_len: usize,
+    stage_num: u32,
+}
+
+impl ProgressWindow {
+    pub fn new() -> Self {
+        let multi_pb = MultiProgress::new();
+        let sty = ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {percent}%")
+            .progress_chars("##-");
+
+        let total_pb = multi_pb.add(ProgressBar::new(100));
+        total_pb.set_style(sty);
+
+        let sty = ProgressStyle::default_bar()
+            .template(" stage {msg:>3} {bar:40.cyan/blue} {percent}%")
+            .progress_chars("##-");
+        let stage_pb = multi_pb.add(ProgressBar::new(100));
+        stage_pb.set_style(sty);
+
+        std::thread::spawn(move || {
+            let _ = multi_pb.join();
+        });
+
+        Self {
+            #[cfg(feature = "progress")]
+            window: None,
+            total_pb,
+            stage_pb,
+            total_len: 100,
+            stage_len: 100,
+            stage_num: 0,
+        }
+    }
+
+    #[cfg(feature = "progress")]
+    pub fn with_preview(
+        mut self,
+        size: Dims,
+        update_every: std::time::Duration,
+    ) -> Result<Self, Error> {
+        let window = Window::new(
+            "Texture Synthesis",
+            size.width as usize,
+            size.height as usize,
+            minifb::WindowOptions::default(),
+        )
+        .unwrap();
+
+        self.window = Some((window, update_every, std::time::Instant::now()));
+
+        Ok(self)
+    }
+}
+
+impl Drop for ProgressWindow {
+    fn drop(&mut self) {
+        self.total_pb.finish();
+        self.stage_pb.finish();
+    }
+}
+
+impl texture_synthesis::GeneratorProgress for ProgressWindow {
+    fn update(&mut self, update: texture_synthesis::ProgressUpdate<'_>) {
+        if update.total.total != self.total_len {
+            self.total_len = update.total.total;
+            self.total_pb.set_length(self.total_len as u64);
+        }
+
+        if update.stage.total != self.stage_len {
+            self.stage_len = update.stage.total;
+            self.stage_pb.set_length(self.stage_len as u64);
+            self.stage_num += 1;
+            self.stage_pb.set_message(&self.stage_num.to_string());
+        }
+
+        self.total_pb.set_position(update.total.current as u64);
+        self.stage_pb.set_position(update.stage.current as u64);
+
+        #[cfg(feature = "progress")]
+        {
+            if let Some((ref mut window, ref dur, ref mut last_update)) = self.window {
+                let now = std::time::Instant::now();
+
+                if now - *last_update < *dur {
+                    return;
+                }
+
+                *last_update = now;
+
+                if !window.is_open() {
+                    return;
+                }
+
+                let pixels = &update.image;
+                if pixels.len() % 4 != 0 {
+                    return;
+                }
+
+                // The pixel channels are in a different order so the colors are
+                // incorrect in the window, but at least the shape and unfilled pixels
+                // are still apparent
+                let pixels: &[u32] = unsafe {
+                    let raw_pixels: &[u8] = pixels;
+                    #[allow(clippy::cast_ptr_alignment)]
+                    std::mem::transmute(&*(raw_pixels as *const [u8] as *const [u32]))
+                };
+
+                // We don't particularly care if this fails
+                let _ = window.update_with_buffer(
+                    pixels,
+                    update.image.width() as usize,
+                    update.image.height() as usize,
+                );
+            }
+        }
+    }
+}

--- a/cli/src/progress_window.rs
+++ b/cli/src/progress_window.rs
@@ -1,3 +1,5 @@
+use texture_synthesis::{Dims, Error};
+
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 #[cfg(feature = "progress")]
 use minifb::Window;

--- a/cli/src/progress_window.rs
+++ b/cli/src/progress_window.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "progress")]
 use texture_synthesis::{Dims, Error};
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,7 +20,6 @@ keywords = ["texture", "synthesis", "procedural"]
 exclude = ["/imgs"]
 
 [dependencies]
-crossbeam-utils = "0.7.0"
 num_cpus = "1.11.1"
 rand = { version = "0.7.3", default-features = false } # avoid bringing in OS random gen that we don't use
 rand_pcg = "0.2.1"
@@ -30,6 +29,9 @@ rstar = "0.7.0"
 version = "0.22.3"
 default-features = false
 features = ["jpeg", "png_codec", "bmp"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+crossbeam-utils = "0.7.0"
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -693,16 +693,12 @@ impl Generator {
             (params.p.powf(p_stage as f32) * (total_pixels_to_resolve as f32)) as usize
         };
 
-        let actual_total_pixels_to_resolve =
-            (0..=params.p_stages).map(stage_pixels_to_resolve).sum();
-
         let is_tiling_mode = params.tiling_mode;
 
         let cauchy_precomputed = PrerenderedU8Function::new(|a, b| {
             metric_cauchy(a, b, params.cauchy_dispersion * params.cauchy_dispersion)
         });
         let l2_precomputed = PrerenderedU8Function::new(metric_l2);
-        let mut total_processed_pixels = 0;
         let max_workers = params.max_thread_count;
         // Use a single R*-tree initially, and fan out to a grid of them later?
         let mut has_fanned_out = false;
@@ -815,189 +811,202 @@ impl Generator {
             pixels_resolved_this_stage.resize_with(n_workers, || Mutex::new(Vec::new()));
             let thread_counter = AtomicUsize::new(0);
 
-            crossbeam_utils::thread::scope(|scope| {
-                for _ in 0..n_workers {
-                    scope.spawn(|_| {
-                        let mut candidates: Vec<CandidateStruct> = Vec::new();
-                        let mut my_pattern: ColorPattern = ColorPattern::new();
-                        let mut k_neighs: Vec<SignedCoord2D> =
-                            Vec::with_capacity(params.nearest_neighbors as usize);
+            let worker_fn = || {
+                let mut candidates: Vec<CandidateStruct> = Vec::new();
+                let mut my_pattern: ColorPattern = ColorPattern::new();
+                let mut k_neighs: Vec<SignedCoord2D> =
+                    Vec::with_capacity(params.nearest_neighbors as usize);
 
-                        let max_candidate_count = params.nearest_neighbors as usize
-                            + params.random_sample_locations as usize;
+                let max_candidate_count =
+                    params.nearest_neighbors as usize + params.random_sample_locations as usize;
 
-                        let my_thread_id = thread_counter.fetch_add(1, Ordering::Relaxed);
-                        let mut my_resolved_list =
-                            pixels_resolved_this_stage[my_thread_id].lock().unwrap();
+                let my_thread_id = thread_counter.fetch_add(1, Ordering::Relaxed);
+                let mut my_resolved_list = pixels_resolved_this_stage[my_thread_id].lock().unwrap();
 
-                        candidates.resize(max_candidate_count, CandidateStruct::default());
+                candidates.resize(max_candidate_count, CandidateStruct::default());
 
-                        //alloc storage for our guides (regardless of whether we have them or not)
-                        let mut my_guide_pattern: ColorPattern = ColorPattern::new();
+                //alloc storage for our guides (regardless of whether we have them or not)
+                let mut my_guide_pattern: ColorPattern = ColorPattern::new();
 
-                        let out_color_map = &[ImageBuffer::from(self.color_map.as_ref())];
+                let out_color_map = &[ImageBuffer::from(self.color_map.as_ref())];
+
+                loop {
+                    // Get the next work item
+                    let i = processed_pixel_count.fetch_add(1, Ordering::Relaxed);
+
+                    let update_resolved_list: bool;
+
+                    if i >= pixels_to_resolve {
+                        // We've processed everything, so finish the worker
+                        break;
+                    }
+
+                    let loop_seed = p_stage_seed + i as u64;
+
+                    // 1. Get a pixel to resolve. Check if we have already resolved pixel i; if yes, resolve again; if no, pick a new one
+                    let next_unresolved = if i < redo_count {
+                        update_resolved_list = false;
+                        self.resolved.read().unwrap()[i + self.locked_resolved].0
+                    } else {
+                        update_resolved_list = true;
+                        if let Some(pixel) = self.pick_random_unresolved(loop_seed) {
+                            pixel
+                        } else {
+                            break;
+                        }
+                    };
+
+                    let unresolved_2d = next_unresolved.to_2d(self.output_size);
+
+                    // Clear previously found candidate neighbors
+                    for cand in candidates.iter_mut() {
+                        cand.clear();
+                    }
+                    k_neighs.clear();
+
+                    // 2. find K nearest resolved neighs
+                    if self.find_k_nearest_resolved_neighs(
+                        unresolved_2d,
+                        params.nearest_neighbors,
+                        &mut k_neighs,
+                    ) {
+                        //2.1 get distances to the pattern of neighbors
+                        let k_neighs_dist =
+                            self.get_distances_to_k_neighs(unresolved_2d, &k_neighs);
+                        let k_neighs_w_map_id =
+                            k_neighs.iter().map(|a| (*a, MapId(0))).collect::<Vec<_>>();
+
+                        // 3. find candidate for each resolved neighs + m random locations
+                        let candidates: &[CandidateStruct] = self.find_candidates(
+                            &mut candidates,
+                            unresolved_2d,
+                            &k_neighs,
+                            &example_maps,
+                            &valid_samples,
+                            params.random_sample_locations as u32,
+                            loop_seed + 1,
+                        );
+
+                        k_neighs_to_precomputed_reference_pattern(
+                            &k_neighs_w_map_id, //feed into the function with always 0 index of the sample map
+                            image::Rgba([0, 0, 0, 255]),
+                            out_color_map,
+                            &mut my_pattern,
+                            is_tiling_mode,
+                        );
+
+                        // 3.2 get pattern for guide map if we have them
+                        let (my_cost, guide_cost) = if let Some(ref in_guides) = guides {
+                            //get example pattern to compare to
+                            k_neighs_to_precomputed_reference_pattern(
+                                &k_neighs_w_map_id,
+                                image::Rgba([0, 0, 0, 255]),
+                                &[in_guides.target_guide.clone()],
+                                &mut my_guide_pattern,
+                                is_tiling_mode,
+                            );
+
+                            (
+                                &my_inverse_alpha_cost_precomputed,
+                                Some(&guide_cost_precomputed),
+                            )
+                        } else {
+                            (&cauchy_precomputed, None)
+                        };
+
+                        // 4. find best match based on the candidate patterns
+                        let (best_match, score) = find_best_match(
+                            image::Rgba([0, 0, 0, 255]),
+                            &example_maps,
+                            &guides,
+                            &candidates,
+                            &my_pattern,
+                            &my_guide_pattern,
+                            &k_neighs_dist,
+                            &my_cost,
+                            guide_cost,
+                        );
+
+                        let best_match_coord = best_match.coord.0.to_unsigned();
+                        let best_match_map_id = best_match.coord.1;
+
+                        // 5. resolve our pixel
+                        self.update(
+                            &mut my_resolved_list,
+                            unresolved_2d,
+                            (best_match_coord, best_match_map_id),
+                            &example_maps,
+                            update_resolved_list,
+                            score,
+                            best_match.id,
+                            is_tiling_mode,
+                        );
+                    } else {
+                        //no resolved neighs? resolve at random!
+                        self.resolve_at_random(
+                            &mut my_resolved_list,
+                            unresolved_2d,
+                            &example_maps,
+                            p_stage_seed,
+                        );
+                    }
+                }
+                remaining_threads.fetch_sub(1, Ordering::Relaxed);
+            };
+
+            // for WASM we do not have threads and crossbeam panics,
+            // so let's just run the worker function directly and don't give progress
+            #[cfg(target_arch = "wasm32")]
+            (worker_fn)();
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let actual_total_pixels_to_resolve: usize =
+                    (0..=params.p_stages).map(stage_pixels_to_resolve).sum();
+                let mut total_processed_pixels = 0;
+
+                crossbeam_utils::thread::scope(|scope| {
+                    for _ in 0..n_workers {
+                        scope.spawn(|_| (worker_fn)());
+                    }
+
+                    if let Some(ref mut progress) = progress {
+                        let mut last_pcnt = 0;
 
                         loop {
-                            // Get the next work item
-                            let i = processed_pixel_count.fetch_add(1, Ordering::Relaxed);
+                            let stage_progress = processed_pixel_count.load(Ordering::Relaxed);
 
-                            let update_resolved_list: bool;
-
-                            if i >= pixels_to_resolve {
-                                // We've processed everything, so finish the worker
+                            if remaining_threads.load(Ordering::Relaxed) == 0 {
                                 break;
                             }
 
-                            let loop_seed = p_stage_seed + i as u64;
+                            let pcnt = ((total_processed_pixels + stage_progress) as f32
+                                / actual_total_pixels_to_resolve as f32
+                                * 100f32)
+                                .round() as u32;
 
-                            // 1. Get a pixel to resolve. Check if we have already resolved pixel i; if yes, resolve again; if no, pick a new one
-                            let next_unresolved = if i < redo_count {
-                                update_resolved_list = false;
-                                self.resolved.read().unwrap()[i + self.locked_resolved].0
-                            } else {
-                                update_resolved_list = true;
-                                if let Some(pixel) = self.pick_random_unresolved(loop_seed) {
-                                    pixel
-                                } else {
-                                    break;
-                                }
-                            };
+                            if pcnt != last_pcnt {
+                                progress.update(crate::ProgressUpdate {
+                                    image: self.color_map.as_ref(),
+                                    total: crate::ProgressStat {
+                                        total: actual_total_pixels_to_resolve,
+                                        current: total_processed_pixels + stage_progress,
+                                    },
+                                    stage: crate::ProgressStat {
+                                        total: pixels_to_resolve,
+                                        current: stage_progress,
+                                    },
+                                });
 
-                            let unresolved_2d = next_unresolved.to_2d(self.output_size);
-
-                            // Clear previously found candidate neighbors
-                            for cand in candidates.iter_mut() {
-                                cand.clear();
-                            }
-                            k_neighs.clear();
-
-                            // 2. find K nearest resolved neighs
-                            if self.find_k_nearest_resolved_neighs(
-                                unresolved_2d,
-                                params.nearest_neighbors,
-                                &mut k_neighs,
-                            ) {
-                                //2.1 get distances to the pattern of neighbors
-                                let k_neighs_dist =
-                                    self.get_distances_to_k_neighs(unresolved_2d, &k_neighs);
-                                let k_neighs_w_map_id =
-                                    k_neighs.iter().map(|a| (*a, MapId(0))).collect::<Vec<_>>();
-
-                                // 3. find candidate for each resolved neighs + m random locations
-                                let candidates: &[CandidateStruct] = self.find_candidates(
-                                    &mut candidates,
-                                    unresolved_2d,
-                                    &k_neighs,
-                                    &example_maps,
-                                    &valid_samples,
-                                    params.random_sample_locations as u32,
-                                    loop_seed + 1,
-                                );
-
-                                k_neighs_to_precomputed_reference_pattern(
-                                    &k_neighs_w_map_id, //feed into the function with always 0 index of the sample map
-                                    image::Rgba([0, 0, 0, 255]),
-                                    out_color_map,
-                                    &mut my_pattern,
-                                    is_tiling_mode,
-                                );
-
-                                // 3.2 get pattern for guide map if we have them
-                                let (my_cost, guide_cost) = if let Some(ref in_guides) = guides {
-                                    //get example pattern to compare to
-                                    k_neighs_to_precomputed_reference_pattern(
-                                        &k_neighs_w_map_id,
-                                        image::Rgba([0, 0, 0, 255]),
-                                        &[in_guides.target_guide.clone()],
-                                        &mut my_guide_pattern,
-                                        is_tiling_mode,
-                                    );
-
-                                    (
-                                        &my_inverse_alpha_cost_precomputed,
-                                        Some(&guide_cost_precomputed),
-                                    )
-                                } else {
-                                    (&cauchy_precomputed, None)
-                                };
-
-                                // 4. find best match based on the candidate patterns
-                                let (best_match, score) = find_best_match(
-                                    image::Rgba([0, 0, 0, 255]),
-                                    &example_maps,
-                                    &guides,
-                                    &candidates,
-                                    &my_pattern,
-                                    &my_guide_pattern,
-                                    &k_neighs_dist,
-                                    &my_cost,
-                                    guide_cost,
-                                );
-
-                                let best_match_coord = best_match.coord.0.to_unsigned();
-                                let best_match_map_id = best_match.coord.1;
-
-                                // 5. resolve our pixel
-                                self.update(
-                                    &mut my_resolved_list,
-                                    unresolved_2d,
-                                    (best_match_coord, best_match_map_id),
-                                    &example_maps,
-                                    update_resolved_list,
-                                    score,
-                                    best_match.id,
-                                    is_tiling_mode,
-                                );
-                            } else {
-                                //no resolved neighs? resolve at random!
-                                self.resolve_at_random(
-                                    &mut my_resolved_list,
-                                    unresolved_2d,
-                                    &example_maps,
-                                    p_stage_seed,
-                                );
+                                last_pcnt = pcnt;
                             }
                         }
-                        remaining_threads.fetch_sub(1, Ordering::Relaxed);
-                    });
-                }
 
-                if let Some(ref mut progress) = progress {
-                    let mut last_pcnt = 0;
-
-                    loop {
-                        let stage_progress = processed_pixel_count.load(Ordering::Relaxed);
-
-                        if remaining_threads.load(Ordering::Relaxed) == 0 {
-                            break;
-                        }
-
-                        let pcnt = ((total_processed_pixels + stage_progress) as f32
-                            / actual_total_pixels_to_resolve as f32
-                            * 100f32)
-                            .round() as u32;
-
-                        if pcnt != last_pcnt {
-                            progress.update(crate::ProgressUpdate {
-                                image: self.color_map.as_ref(),
-                                total: crate::ProgressStat {
-                                    total: actual_total_pixels_to_resolve,
-                                    current: total_processed_pixels + stage_progress,
-                                },
-                                stage: crate::ProgressStat {
-                                    total: pixels_to_resolve,
-                                    current: stage_progress,
-                                },
-                            });
-
-                            last_pcnt = pcnt;
-                        }
+                        total_processed_pixels += pixels_to_resolve;
                     }
-
-                    total_processed_pixels += pixels_to_resolve;
-                }
-            })
-            .unwrap();
+                })
+                .unwrap();
+            }
 
             {
                 // append all per-thread resolved lists to the global list


### PR DESCRIPTION
This adds support for building the lib for both `wasm32-unknown-unknown` and `wasm32-wasi` with single-threaded execution, and for running the CLI with `wasm32-wasi`.

Example:
```sh
rustup target add wasm32-wasi

cargo build --release --target wasm32-wasi

wasmer run ./target/wasm32-wasi/release/texture-synthesis.wasm --mapdir=out:out --mapdir=imgs:imgs -- --out out/01.jpg generate imgs/1.jpg
```

It is not too practical yet without multithreading support (which WASM doesn't support yet), but is very portable and is a good benchmark to test WASM performance with.