### PR TITLE
[Bugfix] Width / Height Typo

### DIFF
--- a/lib/src/multires_stochastic_texture_synthesis.rs
+++ b/lib/src/multires_stochastic_texture_synthesis.rs
@@ -775,7 +775,7 @@ impl Generator {
                 // heuristic: pick a cell size so that the expected number of resolved points in any cell is 4 * k
                 // this seems to be a safe overestimate
                 let grid_cell_size =
-                    ((params.nearest_neighbors * self.output_size.height * self.output_size.height
+                    ((params.nearest_neighbors * self.output_size.width * self.output_size.height
                         / redo_count as u32) as f64)
                         .sqrt() as u32
                         * 2


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
Fixing a typo in my last pr. I should have used `width * height` not `height * height` when figuring out the correct grid size to fan out into.