### PR TITLE
Add project maintainers as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* anopara
+* anopara h3r2tic Jake-Shadle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* anopara


### PR DESCRIPTION
We are making our open source project maintainers explicit with a CODEOWNERS file. Let me know if these are not the correct maintainers for this project